### PR TITLE
fix: update styling for EntityDataReminder

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -160,7 +160,7 @@ const overviewContent = (
 
     <Grid item md={6} xs={12}>
       <CoderProvider appConfig={coderAppConfig}>
-        <CoderWorkspacesCard readEntityData />
+        <CoderWorkspacesCard />
       </CoderProvider>
     </Grid>
 

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -160,7 +160,7 @@ const overviewContent = (
 
     <Grid item md={6} xs={12}>
       <CoderProvider appConfig={coderAppConfig}>
-        <CoderWorkspacesCard />
+        <CoderWorkspacesCard readEntityData />
       </CoderProvider>
     </Grid>
 

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/EntityDataReminder.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/EntityDataReminder.tsx
@@ -1,13 +1,25 @@
 import React, { useState } from 'react';
 import { useId } from '../../hooks/hookPolyfills';
-import { makeStyles } from '@material-ui/core';
+import { Theme, makeStyles } from '@material-ui/core';
 import { VisuallyHidden } from '../VisuallyHidden';
+import { useWorkspacesCardContext } from './Root';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    borderTop: `1px solid ${theme.palette.divider}`,
+type UseStyleProps = Readonly<{
+  hasData: boolean;
+}>;
+
+type UseStyleKeys =
+  | 'root'
+  | 'button'
+  | 'disclosureTriangle'
+  | 'disclosureBody'
+  | 'snippet';
+
+const useStyles = makeStyles<Theme, UseStyleProps, UseStyleKeys>(theme => ({
+  root: ({ hasData }) => ({
     paddingTop: theme.spacing(1),
-  },
+    borderTop: hasData ? 'none' : `1px solid ${theme.palette.divider}`,
+  }),
 
   button: {
     width: '100%',
@@ -55,8 +67,9 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export const EntityDataReminder = () => {
-  const styles = useStyles();
   const [isExpanded, setIsExpanded] = useState(false);
+  const { workspacesQuery } = useWorkspacesCardContext();
+  const styles = useStyles({ hasData: workspacesQuery.data !== undefined });
 
   const hookId = useId();
   const disclosureBodyId = `${hookId}-disclosure-body`;

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/EntityDataReminder.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/EntityDataReminder.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { useId } from '../../hooks/hookPolyfills';
+import { makeStyles } from '@material-ui/core';
+import { VisuallyHidden } from '../VisuallyHidden';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    borderTop: `1px solid ${theme.palette.divider}`,
+    paddingTop: theme.spacing(1),
+  },
+
+  button: {
+    width: '100%',
+    textAlign: 'left',
+    color: theme.palette.text.primary,
+    backgroundColor: theme.palette.background.paper,
+    padding: theme.spacing(1),
+    border: 'none',
+    borderRadius: theme.shape.borderRadius,
+    fontSize: theme.typography.body2.fontSize,
+    cursor: 'pointer',
+
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+
+  disclosureTriangle: {
+    display: 'inline-block',
+    textAlign: 'right',
+    width: theme.spacing(2.25),
+  },
+
+  disclosureBody: {
+    margin: 0,
+    padding: `${theme.spacing(0.5)}px ${theme.spacing(3.5)}px 0 ${theme.spacing(
+      3.75,
+    )}px`,
+  },
+
+  snippet: {
+    color: theme.palette.text.primary,
+    borderRadius: theme.spacing(0.5),
+    padding: `${theme.spacing(0.2)}px ${theme.spacing(1)}px`,
+    backgroundColor: () => {
+      const defaultBackgroundColor = theme.palette.background.default;
+      const isDefaultSpotifyLightTheme =
+        defaultBackgroundColor.toUpperCase() === '#F8F8F8';
+
+      return isDefaultSpotifyLightTheme
+        ? 'hsl(0deg,0%,93%)'
+        : defaultBackgroundColor;
+    },
+  },
+}));
+
+export const EntityDataReminder = () => {
+  const styles = useStyles();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const hookId = useId();
+  const disclosureBodyId = `${hookId}-disclosure-body`;
+
+  // Might be worth revisiting the markup here to try implementing this
+  // functionality with <detail> and <summary> elements. Would likely clean up
+  // the component code a ton but might reduce control over screen reader output
+  return (
+    <div className={styles.root}>
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        aria-controls={disclosureBodyId}
+        onClick={() => setIsExpanded(!isExpanded)}
+        className={styles.button}
+      >
+        <span aria-hidden className={styles.disclosureTriangle}>
+          {isExpanded ? '▼' : '►'}
+        </span>{' '}
+        {isExpanded ? 'Hide text' : 'Why am I seeing all workspaces?'}
+      </button>
+
+      {isExpanded && (
+        <p id={disclosureBodyId} className={styles.disclosureBody}>
+          This component displays all workspaces when the entity has no repo URL
+          to filter by. Consider disabling{' '}
+          <code className={styles.snippet}>readEntityData</code> (details in our{' '}
+          <a
+            href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#notes-4"
+            rel="noopener noreferrer"
+            target="_blank"
+            style={{ textDecoration: 'underline', color: 'inherit' }}
+          >
+            documentation
+            <VisuallyHidden> (link opens in new tab)</VisuallyHidden>
+          </a>
+          ).
+        </p>
+      )}
+    </div>
+  );
+};

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Root.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Root.tsx
@@ -4,7 +4,6 @@ import React, {
   useContext,
   useState,
 } from 'react';
-import { makeStyles } from '@material-ui/core';
 import { useId } from '../../hooks/hookPolyfills';
 import { UseQueryResult } from '@tanstack/react-query';
 import {
@@ -16,8 +15,9 @@ import type { Workspace } from '../../typesConstants';
 import { useCoderWorkspaces } from '../../hooks/useCoderWorkspaces';
 import { Card } from '../Card';
 import { CoderAuthWrapper } from '../CoderAuthWrapper';
-import { VisuallyHidden } from '../VisuallyHidden';
+
 import { type CoderWorkspaceConfig, useCoderAppConfig } from '../CoderProvider';
+import { EntityDataReminder } from './EntityDataReminder';
 
 type WorkspacesCardContext = Readonly<{
   queryFilter: string;
@@ -29,22 +29,6 @@ type WorkspacesCardContext = Readonly<{
 }>;
 
 const CardContext = createContext<WorkspacesCardContext | null>(null);
-
-const useStyles = makeStyles(theme => ({
-  button: {
-    color: theme.palette.type,
-    backgroundColor: theme.palette.background.paper,
-    border: 'none',
-    paddingTop: theme.spacing(2),
-    fontSize: theme.typography.body2.fontSize,
-    cursor: 'pointer',
-  },
-
-  snippet: {
-    backgroundColor: theme.palette.grey[100],
-    borderRadius: '0.4em',
-  },
-}));
 
 export type WorkspacesCardProps = Readonly<
   Omit<HTMLAttributes<HTMLDivElement>, 'role' | 'aria-labelledby'> & {
@@ -64,29 +48,26 @@ export const Root = ({
   readEntityData = false,
   ...delegatedProps
 }: WorkspacesCardProps) => {
-  const styles = useStyles();
   const hookId = useId();
   const appConfig = useCoderAppConfig();
   const [innerFilter, setInnerFilter] = useState(defaultQueryFilter);
   const activeFilter = outerFilter ?? innerFilter;
 
-  const [isExpanded, setIsExpanded] = useState(false);
-  const toggleExpansion = () => {
-    setIsExpanded(!isExpanded);
-  };
-
   const dynamicConfig = useDynamicEntityConfig(readEntityData);
   const workspacesQuery = useCoderWorkspaces(activeFilter, {
     repoConfig: dynamicConfig,
   });
-  const showEntityDataReminder =
-    workspacesQuery.data && dynamicConfig && !dynamicConfig.repoUrl;
 
   const headerId = `${hookId}-header`;
   const activeConfig = {
     ...appConfig.workspaces,
     ...(dynamicConfig ?? {}),
   };
+
+  const showEntityDataReminder =
+    workspacesQuery.data !== undefined &&
+    dynamicConfig !== undefined &&
+    !dynamicConfig.repoUrl;
 
   return (
     <CoderAuthWrapper type="card">
@@ -119,36 +100,7 @@ export const Root = ({
               cases around keyboard input and button children that native <form>
               elements automatically introduce */}
           <div role="form">{children}</div>
-          {showEntityDataReminder && (
-            <div>
-              <button
-                onClick={toggleExpansion}
-                type="button"
-                className={styles.button}
-              >
-                {isExpanded ? '▼' : '►'}{' '}
-                {isExpanded ? 'Hide text' : 'Why am I seeing all workspaces?'}
-              </button>
-              {isExpanded && (
-                <p>
-                  This component displays all workspaces when the entity has no
-                  repo URL to filter by. Consider disabling{' '}
-                  <code className={styles.snippet}>readEntityData</code>;
-                  details in our{' '}
-                  <a
-                    href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#notes-4"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    style={{ textDecoration: 'underline', color: 'inherit' }}
-                  >
-                    docs
-                    <VisuallyHidden> (link opens in new tab)</VisuallyHidden>
-                  </a>
-                  .
-                </p>
-              )}
-            </div>
-          )}
+          {showEntityDataReminder && <EntityDataReminder />}
         </Card>
       </CardContext.Provider>
     </CoderAuthWrapper>

--- a/plugins/backstage-plugin-coder/src/hooks/hookPolyfills.ts
+++ b/plugins/backstage-plugin-coder/src/hooks/hookPolyfills.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 let idCounter = 0;
 
@@ -13,14 +13,17 @@ let idCounter = 0;
  *
  * @see {@link https://react.dev/reference/react/useId}
  */
-export function useId(): string {
-  // Dirty initialiation - this does break the "renders should always be pure"
+function useIdPolyfill(): string {
+  // Dirty initialization - this does break the "renders should always be pure"
   // rule, but it's being done in a controlled way, and there's no other way to
   // ensure a truly unique value is available on the very first render.
-  const [readonlyIdRoot] = useState(() => {
+  const [readonlyId] = useState(() => {
     idCounter++;
-    return String(idCounter);
+    return `:r${idCounter}:`;
   });
 
-  return `:r${readonlyIdRoot}:`;
+  return readonlyId;
 }
+
+export const useId =
+  typeof React.useId === 'undefined' ? useIdPolyfill : React.useId;


### PR DESCRIPTION
Closes #50 

## Changes made
- Split `DataEntityReminder` off into a separate component
   - Updated the semantics and improved screen reader support
   - Updated styling to work consistently across light mode and dark mode
   - Changed some alignment on the text elements
   - Increased the width of the reminder button to make it easier to click, and added hover styling
- Updated logic for the `useId` polyfill
   - Since we have React 18 now, the file will return out the native `useId` when available, but fall back to the polyfill when on React 16/17

<img width="627" alt="Screenshot 2024-03-18 at 11 57 08 AM" src="https://github.com/coder/backstage-plugins/assets/28937484/4188ca27-0bfc-4319-bd38-679dcdb9ee93">
<img width="627" alt="Screenshot 2024-03-18 at 11 57 19 AM" src="https://github.com/coder/backstage-plugins/assets/28937484/2ef0c1cb-a15c-4827-9140-15c5a0e8c067">
