### PR TITLE
chore: add tests for frontend devcontainers plugin

### DIFF
--- a/plugins/backstage-plugin-devcontainers-react/src/components/DevcontainersProvider/DevcontainersProvider.test.tsx
+++ b/plugins/backstage-plugin-devcontainers-react/src/components/DevcontainersProvider/DevcontainersProvider.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import {
+  DEFAULT_DEVCONTAINERS_TAG,
+  DevcontainersConfig,
+  DevcontainersProvider,
+  useDevcontainersConfig,
+} from './DevcontainersProvider';
+
+const baseConfig: DevcontainersConfig = { tagName: 'test' };
+
+describe(`${DevcontainersProvider.name}`, () => {
+  it('Stabilizes the memory reference for the config value when defined outside the component', () => {
+    const { result, rerender } = renderHook(useDevcontainersConfig, {
+      wrapper: ({ children }) => (
+        <DevcontainersProvider config={baseConfig}>
+          {children}
+        </DevcontainersProvider>
+      ),
+    });
+
+    const initialResult = result.current;
+    rerender();
+    expect(result.current).toBe(initialResult);
+  });
+
+  it('Will update the memory reference for the config each render if it is accidentally passed inline', () => {
+    const { result, rerender } = renderHook(useDevcontainersConfig, {
+      wrapper: ({ children }) => (
+        <DevcontainersProvider config={{ ...baseConfig }}>
+          {children}
+        </DevcontainersProvider>
+      ),
+    });
+
+    const initialResult = result.current;
+    rerender();
+    expect(result.current).not.toBe(initialResult);
+    expect(result.current).toEqual(initialResult);
+  });
+
+  it("Uses the default devcontainers tag when a tag override isn't provided", () => {
+    const { result } = renderHook(useDevcontainersConfig, {
+      wrapper: ({ children }) => (
+        <DevcontainersProvider config={{}}>{children}</DevcontainersProvider>
+      ),
+    });
+
+    expect(result.current.tagName).toBe(DEFAULT_DEVCONTAINERS_TAG);
+  });
+});

--- a/plugins/backstage-plugin-devcontainers-react/src/components/DevcontainersProvider/DevcontainersProvider.test.tsx
+++ b/plugins/backstage-plugin-devcontainers-react/src/components/DevcontainersProvider/DevcontainersProvider.test.tsx
@@ -40,9 +40,12 @@ describe(`${DevcontainersProvider.name}`, () => {
   });
 
   it("Uses the default devcontainers tag when a tag override isn't provided", () => {
+    const emptyConfig: DevcontainersConfig = {};
     const { result } = renderHook(useDevcontainersConfig, {
       wrapper: ({ children }) => (
-        <DevcontainersProvider config={{}}>{children}</DevcontainersProvider>
+        <DevcontainersProvider config={emptyConfig}>
+          {children}
+        </DevcontainersProvider>
       ),
     });
 

--- a/plugins/backstage-plugin-devcontainers-react/src/components/DevcontainersProvider/DevcontainersProvider.tsx
+++ b/plugins/backstage-plugin-devcontainers-react/src/components/DevcontainersProvider/DevcontainersProvider.tsx
@@ -5,7 +5,7 @@ import React, {
   useMemo,
 } from 'react';
 
-const DEFAULT_DEVCONTAINERS_TAG = 'devcontainers-plugin';
+export const DEFAULT_DEVCONTAINERS_TAG = 'devcontainers-plugin';
 
 export type DevcontainersConfig = Readonly<{
   /**

--- a/plugins/backstage-plugin-devcontainers-react/src/hooks/useDevcontainers.test.tsx
+++ b/plugins/backstage-plugin-devcontainers-react/src/hooks/useDevcontainers.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { useDevcontainers } from './useDevcontainers';
+import { type DevcontainersConfig, DevcontainersProvider } from '../plugin';
+import { wrapInTestApp } from '@backstage/test-utils';
+import { EntityProvider, useEntity } from '@backstage/plugin-catalog-react';
+import { ANNOTATION_SOURCE_LOCATION } from '@backstage/catalog-model';
+
+const mockTagName = 'devcontainers-test';
+const mockUrlRoot = 'https://www.github.com/example-company/example-repo';
+
+type BackstageEntity = ReturnType<typeof useEntity>['entity'];
+const mockEntity: BackstageEntity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'metadata',
+    tags: [mockTagName],
+    annotations: {
+      [ANNOTATION_SOURCE_LOCATION]: `${mockUrlRoot}/tree/main`,
+    },
+  },
+};
+
+function render(tagName: string) {
+  const config: DevcontainersConfig = { tagName };
+
+  return renderHook(useDevcontainers, {
+    wrapper: ({ children }) =>
+      wrapInTestApp(
+        <EntityProvider entity={mockEntity}>
+          <DevcontainersProvider config={config}>
+            {children}
+          </DevcontainersProvider>
+        </EntityProvider>,
+      ),
+  });
+}
+
+describe(`${useDevcontainers.name}`, () => {
+  it('Does not expose a link when the designated devcontainers tag is missing', () => {
+    const { result } = render('this-tag-should-not-be-found');
+    expect(result.current.vsCodeUrl).toBe(undefined);
+  });
+
+  it('Provides a VS Code-formatted link when the current entity has a devcontainers tag', () => {
+    const { result } = render(mockTagName);
+    expect(result.current.vsCodeUrl).toEqual(
+      `vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=${mockUrlRoot}`,
+    );
+  });
+});

--- a/plugins/backstage-plugin-devcontainers-react/src/hooks/useDevcontainers.test.tsx
+++ b/plugins/backstage-plugin-devcontainers-react/src/hooks/useDevcontainers.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useDevcontainers } from './useDevcontainers';
 import { type DevcontainersConfig, DevcontainersProvider } from '../plugin';
 import { wrapInTestApp } from '@backstage/test-utils';
@@ -10,7 +10,7 @@ const mockTagName = 'devcontainers-test';
 const mockUrlRoot = 'https://www.github.com/example-company/example-repo';
 
 type BackstageEntity = ReturnType<typeof useEntity>['entity'];
-const mockEntity: BackstageEntity = {
+const baseEntity: BackstageEntity = {
   apiVersion: 'backstage.io/v1alpha1',
   kind: 'Component',
   metadata: {
@@ -22,29 +22,59 @@ const mockEntity: BackstageEntity = {
   },
 };
 
-function render(tagName: string) {
+async function render(tagName: string, entity: BackstageEntity) {
   const config: DevcontainersConfig = { tagName };
 
-  return renderHook(useDevcontainers, {
+  const output = renderHook(useDevcontainers, {
     wrapper: ({ children }) =>
       wrapInTestApp(
-        <EntityProvider entity={mockEntity}>
+        <EntityProvider entity={entity}>
           <DevcontainersProvider config={config}>
             {children}
           </DevcontainersProvider>
         </EntityProvider>,
       ),
   });
+
+  // The mock Backstage client needs a little bit of time to spin up for the
+  // first render, but will be ready to go for all test cases after that. In
+  // practice, this means that unless you wait for the hook result to be
+  // rendered and ejected via the wrapper, the first test case will ALWAYS fail,
+  // no matter what it does. Have to make all test cases async to ensure that
+  // shuffling test cases around doesn't randomly kick up false positives
+  await waitFor(() => expect(output.result.current).not.toBe(null));
+  return output;
 }
 
 describe(`${useDevcontainers.name}`, () => {
-  it('Does not expose a link when the designated devcontainers tag is missing', () => {
-    const { result } = render('this-tag-should-not-be-found');
+  it('Does not expose a link when the designated devcontainers tag is missing', async () => {
+    const { result: result1 } = await render('tag-not-found', baseEntity);
+    const { result: result2 } = await render(mockTagName, {
+      ...baseEntity,
+      metadata: {
+        ...baseEntity.metadata,
+        tags: [],
+      },
+    });
+
+    expect(result1.current.vsCodeUrl).toBe(undefined);
+    expect(result2.current.vsCodeUrl).toBe(undefined);
+  });
+
+  it('Does not expose a link when the entity lacks a repo URL', async () => {
+    const { result } = await render(mockTagName, {
+      ...baseEntity,
+      metadata: {
+        ...baseEntity.metadata,
+        annotations: {},
+      },
+    });
+
     expect(result.current.vsCodeUrl).toBe(undefined);
   });
 
-  it('Provides a VS Code-formatted link when the current entity has a designated devcontainers tag', () => {
-    const { result } = render(mockTagName);
+  it('Provides a VS Code-formatted link when the current entity has a designated devcontainers tag', async () => {
+    const { result } = await render(mockTagName, baseEntity);
     expect(result.current.vsCodeUrl).toEqual(
       `vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=${mockUrlRoot}`,
     );

--- a/plugins/backstage-plugin-devcontainers-react/src/hooks/useDevcontainers.test.tsx
+++ b/plugins/backstage-plugin-devcontainers-react/src/hooks/useDevcontainers.test.tsx
@@ -15,7 +15,7 @@ const mockEntity: BackstageEntity = {
   kind: 'Component',
   metadata: {
     name: 'metadata',
-    tags: [mockTagName],
+    tags: [mockTagName, 'other', 'random', 'values'],
     annotations: {
       [ANNOTATION_SOURCE_LOCATION]: `${mockUrlRoot}/tree/main`,
     },
@@ -43,7 +43,7 @@ describe(`${useDevcontainers.name}`, () => {
     expect(result.current.vsCodeUrl).toBe(undefined);
   });
 
-  it('Provides a VS Code-formatted link when the current entity has a devcontainers tag', () => {
+  it('Provides a VS Code-formatted link when the current entity has a designated devcontainers tag', () => {
     const { result } = render(mockTagName);
     expect(result.current.vsCodeUrl).toEqual(
       `vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=${mockUrlRoot}`,


### PR DESCRIPTION
Closes #58

This should cover everything we need for the frontend (until we get more feedback/requests for new features). 

## Changes made
- Added test cases for `DevcontainersProvider`
- Added test cases for `useDevcontainers`