### PR TITLE
chore: make VisuallyHidden display overrides harder to trigger in dev mode

### DIFF
--- a/plugins/backstage-plugin-coder/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/plugins/backstage-plugin-coder/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -31,6 +31,7 @@ type VisuallyHiddenProps = HTMLAttributes<HTMLElement> & {
 
 export const VisuallyHidden = ({
   children,
+  style,
   ...delegatedProps
 }: VisuallyHiddenProps) => {
   const [forceShow, setForceShow] = useState(false);
@@ -61,10 +62,17 @@ export const VisuallyHidden = ({
     };
   }, []);
 
-  return forceShow ? (
-    <>{children}</>
-  ) : (
-    <span style={visuallyHiddenStyles} {...delegatedProps}>
+  if (forceShow) {
+    return <>{children}</>;
+  }
+
+  return (
+    <span
+      style={
+        style ? { ...visuallyHiddenStyles, ...style } : visuallyHiddenStyles
+      }
+      {...delegatedProps}
+    >
       {children}
     </span>
   );

--- a/plugins/backstage-plugin-coder/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/plugins/backstage-plugin-coder/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -25,13 +25,12 @@ const visuallyHiddenStyles: CSSProperties = {
   border: 0,
 };
 
-type VisuallyHiddenProps = HTMLAttributes<HTMLElement> & {
+type VisuallyHiddenProps = Omit<HTMLAttributes<HTMLElement>, 'style'> & {
   children: ReactNode;
 };
 
 export const VisuallyHidden = ({
   children,
-  style,
   ...delegatedProps
 }: VisuallyHiddenProps) => {
   const [forceShow, setForceShow] = useState(false);
@@ -67,12 +66,7 @@ export const VisuallyHidden = ({
   }
 
   return (
-    <span
-      style={
-        style ? { ...visuallyHiddenStyles, ...style } : visuallyHiddenStyles
-      }
-      {...delegatedProps}
-    >
+    <span style={visuallyHiddenStyles} {...delegatedProps}>
       {children}
     </span>
   );

--- a/plugins/backstage-plugin-coder/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/plugins/backstage-plugin-coder/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -40,14 +40,14 @@ export const VisuallyHidden = ({
       return undefined;
     }
 
-    const handleKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key === 'Alt') {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.shiftKey && event.key === 'Alt') {
         setForceShow(true);
       }
     };
 
-    const handleKeyUp = (ev: KeyboardEvent) => {
-      if (ev.key === 'Alt') {
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key === 'Alt') {
         setForceShow(false);
       }
     };

--- a/plugins/backstage-plugin-devcontainers-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/plugins/backstage-plugin-devcontainers-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -31,6 +31,7 @@ type VisuallyHiddenProps = HTMLAttributes<HTMLElement> & {
 
 export const VisuallyHidden = ({
   children,
+  style,
   ...delegatedProps
 }: VisuallyHiddenProps) => {
   const [forceShow, setForceShow] = useState(false);
@@ -61,10 +62,17 @@ export const VisuallyHidden = ({
     };
   }, []);
 
-  return forceShow ? (
-    <>{children}</>
-  ) : (
-    <span style={visuallyHiddenStyles} {...delegatedProps}>
+  if (forceShow) {
+    return <>{children}</>;
+  }
+
+  return (
+    <span
+      style={
+        style ? { ...visuallyHiddenStyles, ...style } : visuallyHiddenStyles
+      }
+      {...delegatedProps}
+    >
       {children}
     </span>
   );

--- a/plugins/backstage-plugin-devcontainers-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/plugins/backstage-plugin-devcontainers-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -25,13 +25,12 @@ const visuallyHiddenStyles: CSSProperties = {
   border: 0,
 };
 
-type VisuallyHiddenProps = HTMLAttributes<HTMLElement> & {
+type VisuallyHiddenProps = Omit<HTMLAttributes<HTMLElement>, 'style'> & {
   children: ReactNode;
 };
 
 export const VisuallyHidden = ({
   children,
-  style,
   ...delegatedProps
 }: VisuallyHiddenProps) => {
   const [forceShow, setForceShow] = useState(false);
@@ -67,12 +66,7 @@ export const VisuallyHidden = ({
   }
 
   return (
-    <span
-      style={
-        style ? { ...visuallyHiddenStyles, ...style } : visuallyHiddenStyles
-      }
-      {...delegatedProps}
-    >
+    <span style={visuallyHiddenStyles} {...delegatedProps}>
       {children}
     </span>
   );

--- a/plugins/backstage-plugin-devcontainers-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/plugins/backstage-plugin-devcontainers-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -40,14 +40,14 @@ export const VisuallyHidden = ({
       return undefined;
     }
 
-    const handleKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key === 'Alt') {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.shiftKey && event.key === 'Alt') {
         setForceShow(true);
       }
     };
 
-    const handleKeyUp = (ev: KeyboardEvent) => {
-      if (ev.key === 'Alt') {
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key === 'Alt') {
         setForceShow(false);
       }
     };


### PR DESCRIPTION
No PR to link – realized this was more necessary after trying to make the demo video yesterday

## Changes made
- Made it so that you now have to trigger the VisuallyHidden override by holding Shift first, and then pressing Alt/Option
- Made sure that the `style` prop is no longer able to be passed to the component (the component is supposed to be visually hidden, so there's no need to style it further)

## Notes
- I think part of the reason I didn't notice the issues around how easy it was to trigger the text is that I (probably like Josh Comeau) open the dev tools via F12, and didn't realize that opening the tools the other way didn't always remove the force-show styles. Sorry about that!