### PR TITLE
chore: add all missing tests for backstage-plugin-coder

### DIFF
--- a/plugins/backstage-plugin-coder/src/components/CoderAuthWrapper/CoderAuthInputForm.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderAuthWrapper/CoderAuthInputForm.tsx
@@ -95,12 +95,21 @@ export const CoderAuthInputForm = () => {
     registerNewToken(newToken);
   };
 
+  const formHeaderId = `${hookId}-form-header`;
   const legendId = `${hookId}-legend`;
   const authTokenInputId = `${hookId}-auth-token`;
   const warningBannerId = `${hookId}-warning-banner`;
 
   return (
-    <form className={styles.formContainer} onSubmit={onSubmit}>
+    <form
+      aria-labelledby={formHeaderId}
+      className={styles.formContainer}
+      onSubmit={onSubmit}
+    >
+      <h3 hidden id={formHeaderId}>
+        Authenticate with Coder
+      </h3>
+
       <div>
         <CoderLogo className={styles.coderLogo} />
         <p>

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @file Defines integration tests for all sub-components in the
+ * CoderWorkspacesCard directory.
+ */
+import React from 'react';
+import { mockAuthStates } from '../../testHelpers/mockBackstageData';
+import { renderInCoderEnvironment } from '../../testHelpers/setup';
+import { type CoderAuthStatus } from '../CoderProvider';
+import { CoderWorkspacesCard } from './CoderWorkspacesCard';
+import { screen } from '@testing-library/react';
+
+type RenderInputs = Readonly<{
+  authStatus?: CoderAuthStatus;
+  readEntityData?: boolean;
+}>;
+
+function renderWorkspacesCard(input?: RenderInputs) {
+  const { authStatus = 'authenticated', readEntityData = false } = input ?? {};
+
+  return renderInCoderEnvironment({
+    auth: mockAuthStates[authStatus],
+    children: <CoderWorkspacesCard readEntityData={readEntityData} />,
+  });
+}
+
+describe(`${CoderWorkspacesCard.name}`, () => {
+  describe('General behavior', () => {
+    it.only('Shows the authentication form when the user is not authenticated', async () => {
+      await renderWorkspacesCard({
+        authStatus: 'tokenMissing',
+      });
+
+      expect(() => {
+        screen.getByRole('form', {
+          name: /Authenticate with Coder/i,
+        });
+      }).not.toThrow();
+    });
+
+    it('Shows the workspaces list when the user is authenticated', async () => {});
+    it('Is exposed as an accessible search landmark when the workspaces card is visible', async () => {});
+  });
+
+  describe('With readEntityData set to false', () => {
+    it('Will NOT filter any workspaces by current repo', async () => {});
+    it('Lets the user filter the workspaces by their query text', async () => {});
+    it('Shows all workspaces when query text is empty', async () => {});
+  });
+
+  describe('With readEntityData set to true', () => {
+    it('Will show only the workspaces that match the current repo', async () => {});
+    it('Lets the user filter the workspaces by their query text (on top of filtering from readEntityData)', async () => {});
+
+    /**
+     * 2024-03-28 - MES - This is a test case to account for a previous
+     * limitation around querying workspaces by repo URL.
+     *
+     * This limitation no longer exists, so this test should be removed once the
+     * rest of the codebase is updated to support the new API endpoint for
+     * searching by build parameter
+     */
+    it('Will not show any workspaces at all when the query text is empty', async () => {});
+  });
+});

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
@@ -3,11 +3,12 @@
  * CoderWorkspacesCard directory.
  */
 import React from 'react';
-import { mockAuthStates } from '../../testHelpers/mockBackstageData';
+import { screen, waitFor } from '@testing-library/react';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
+import { mockAuthStates } from '../../testHelpers/mockBackstageData';
+import { mockWorkspacesList } from '../../testHelpers/mockCoderAppData';
 import { type CoderAuthStatus } from '../CoderProvider';
 import { CoderWorkspacesCard } from './CoderWorkspacesCard';
-import { screen } from '@testing-library/react';
 
 type RenderInputs = Readonly<{
   authStatus?: CoderAuthStatus;
@@ -25,7 +26,7 @@ function renderWorkspacesCard(input?: RenderInputs) {
 
 describe(`${CoderWorkspacesCard.name}`, () => {
   describe('General behavior', () => {
-    it.only('Shows the authentication form when the user is not authenticated', async () => {
+    it('Shows the authentication form when the user is not authenticated', async () => {
       await renderWorkspacesCard({
         authStatus: 'tokenMissing',
       });
@@ -37,12 +38,32 @@ describe(`${CoderWorkspacesCard.name}`, () => {
       }).not.toThrow();
     });
 
-    it('Shows the workspaces list when the user is authenticated', async () => {});
-    it('Is exposed as an accessible search landmark when the workspaces card is visible', async () => {});
+    it('Shows the workspaces list when the user is authenticated (exposed as an accessible search landmark)', async () => {
+      await renderWorkspacesCard({
+        authStatus: 'authenticated',
+      });
+
+      await waitFor(() => {
+        expect(() => {
+          screen.getByRole('search', {
+            name: /Coder Workspaces/i,
+          });
+        }).not.toThrow();
+      });
+    });
   });
 
   describe('With readEntityData set to false', () => {
-    it('Will NOT filter any workspaces by current repo', async () => {});
+    it.only('Will NOT filter any workspaces by the current repo', async () => {
+      await renderWorkspacesCard({
+        authStatus: 'authenticated',
+        readEntityData: false,
+      });
+
+      const workspaceItems = await screen.findAllByRole('listitem');
+      expect(workspaceItems.length).toEqual(mockWorkspacesList.length);
+    });
+
     it('Lets the user filter the workspaces by their query text', async () => {});
     it('Shows all workspaces when query text is empty', async () => {});
   });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
@@ -130,7 +130,7 @@ describe(`${CoderWorkspacesCard.name}`, () => {
      * rest of the codebase is updated to support the new API endpoint for
      * searching by build parameter
      */
-    it.only('Will not show any workspaces at all when the query text is empty', async () => {
+    it('Will not show any workspaces at all when the query text is empty', async () => {
       await renderWorkspacesCard({ readEntityData: true });
 
       const user = userEvent.setup();
@@ -141,7 +141,10 @@ describe(`${CoderWorkspacesCard.name}`, () => {
       await user.tripleClick(inputField);
       await user.keyboard('[Backspace]');
 
-      const empty = await screen.findByText(/No workspaces found for repo/);
+      const empty = await screen.findByText(
+        /Use the search bar to find matching Coder workspaces/,
+      );
+
       expect(empty).toBeInTheDocument();
     });
   });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
@@ -131,7 +131,18 @@ describe(`${CoderWorkspacesCard.name}`, () => {
      * searching by build parameter
      */
     it.only('Will not show any workspaces at all when the query text is empty', async () => {
-      expect.hasAssertions();
+      await renderWorkspacesCard({ readEntityData: true });
+
+      const user = userEvent.setup();
+      const inputField = await screen.findByRole('searchbox', {
+        name: /Search your Coder workspaces/i,
+      });
+
+      await user.tripleClick(inputField);
+      await user.keyboard('[Backspace]');
+
+      const empty = await screen.findByText(/No workspaces found for repo/);
+      expect(empty).toBeInTheDocument();
     });
   });
 });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
@@ -141,11 +141,11 @@ describe(`${CoderWorkspacesCard.name}`, () => {
       await user.tripleClick(inputField);
       await user.keyboard('[Backspace]');
 
-      const empty = await screen.findByText(
+      const emptyState = await screen.findByText(
         /Use the search bar to find matching Coder workspaces/,
       );
 
-      expect(empty).toBeInTheDocument();
+      expect(emptyState).toBeInTheDocument();
     });
   });
 });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
@@ -97,7 +97,7 @@ describe(`${CoderWorkspacesCard.name}`, () => {
     it('Will show only the workspaces that match the current repo', async () => {
       await renderWorkspacesCard({ readEntityData: true });
       const workspaceItems = await screen.findAllByRole('listitem');
-      expect(workspaceItems.length).toEqual(1);
+      expect(workspaceItems.length).toEqual(2);
     });
 
     it('Lets the user filter the workspaces by their query text (on top of filtering from readEntityData)', async () => {

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
@@ -54,6 +54,34 @@ describe(`${CoderWorkspacesCard.name}`, () => {
         }).not.toThrow();
       });
     });
+
+    it('Shows zero workspaces when the query text matches nothing', async () => {
+      const entityValues = [true, false] as const;
+      const user = userEvent.setup();
+
+      for (const value of entityValues) {
+        const { unmount } = await renderWorkspacesCard({
+          readEntityData: value,
+        });
+
+        const inputField = await screen.findByRole('searchbox', {
+          name: /Search your Coder workspaces/i,
+        });
+
+        await user.tripleClick(inputField);
+        await user.keyboard('[Backspace]');
+        await user.keyboard('I can do it - I can do it nine times');
+
+        await waitFor(() => {
+          // getAllByRole would normally give us an array of all nodes, but it
+          // throws unless it finds at least one node. Have to assert that the
+          // selection fails instead
+          expect(() => screen.getByRole('listitem')).toThrow();
+        });
+
+        unmount();
+      }
+    });
   });
 
   describe('With readEntityData set to false', () => {

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
@@ -76,10 +76,9 @@ describe(`${CoderWorkspacesCard.name}`, () => {
         await user.keyboard('I can do it - I can do it nine times');
 
         await waitFor(() => {
-          // getAllByRole would normally give us an array of all nodes, but it
-          // throws unless it finds at least one node. Have to assert that the
-          // selection fails instead
-          expect(() => screen.getByRole('listitem')).toThrow();
+          // getAllByRole will throw if there isn't at least one node matched
+          const listItems = screen.queryAllByRole('listitem');
+          expect(listItems.length).toBe(0);
         });
 
         unmount();
@@ -173,7 +172,6 @@ describe(`${CoderWorkspacesCard.name}`, () => {
       await user.keyboard('[Backspace]');
 
       const emptyState = await screen.findByText(matchers.emptyState);
-
       expect(emptyState).toBeInTheDocument();
     });
   });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
@@ -6,9 +6,13 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
 import { mockAuthStates } from '../../testHelpers/mockBackstageData';
-import { mockWorkspacesList } from '../../testHelpers/mockCoderAppData';
+import {
+  mockWorkspaceNoParameters,
+  mockWorkspacesList,
+} from '../../testHelpers/mockCoderAppData';
 import { type CoderAuthStatus } from '../CoderProvider';
 import { CoderWorkspacesCard } from './CoderWorkspacesCard';
+import userEvent from '@testing-library/user-event';
 
 type RenderInputs = Readonly<{
   authStatus?: CoderAuthStatus;
@@ -54,7 +58,7 @@ describe(`${CoderWorkspacesCard.name}`, () => {
   });
 
   describe('With readEntityData set to false', () => {
-    it.only('Will NOT filter any workspaces by the current repo', async () => {
+    it('Will NOT filter any workspaces by the current repo', async () => {
       await renderWorkspacesCard({
         authStatus: 'authenticated',
         readEntityData: false,
@@ -64,7 +68,25 @@ describe(`${CoderWorkspacesCard.name}`, () => {
       expect(workspaceItems.length).toEqual(mockWorkspacesList.length);
     });
 
-    it('Lets the user filter the workspaces by their query text', async () => {});
+    it.only('Lets the user filter the workspaces by their query text', async () => {
+      await renderWorkspacesCard({
+        authStatus: 'authenticated',
+        readEntityData: false,
+      });
+
+      const inputField = await screen.findByRole('searchbox', {
+        name: /Search your Coder workspaces/i,
+      });
+
+      const user = userEvent.setup();
+      await user.tripleClick(inputField);
+      await user.keyboard(mockWorkspaceNoParameters.name);
+
+      // If more than one workspace matches, that throws an error
+      const onlyWorkspace = await screen.findByRole('listitem');
+      expect(onlyWorkspace).toHaveTextContent(mockWorkspaceNoParameters.name);
+    });
+
     it('Shows all workspaces when query text is empty', async () => {});
   });
 

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.test.tsx
@@ -29,6 +29,13 @@ function renderWorkspacesCard(input?: RenderInputs) {
   });
 }
 
+const matchers = {
+  authenticationForm: /Authenticate with Coder/i,
+  searchTitle: /Coder Workspaces/i,
+  searchbox: /Search your Coder workspaces/i,
+  emptyState: /Use the search bar to find matching Coder workspaces/i,
+} as const satisfies Record<string, RegExp>;
+
 describe(`${CoderWorkspacesCard.name}`, () => {
   describe('General behavior', () => {
     it('Shows the authentication form when the user is not authenticated', async () => {
@@ -37,9 +44,7 @@ describe(`${CoderWorkspacesCard.name}`, () => {
       });
 
       expect(() => {
-        screen.getByRole('form', {
-          name: /Authenticate with Coder/i,
-        });
+        screen.getByRole('form', { name: matchers.authenticationForm });
       }).not.toThrow();
     });
 
@@ -48,9 +53,7 @@ describe(`${CoderWorkspacesCard.name}`, () => {
 
       await waitFor(() => {
         expect(() => {
-          screen.getByRole('search', {
-            name: /Coder Workspaces/i,
-          });
+          screen.getByRole('search', { name: matchers.searchTitle });
         }).not.toThrow();
       });
     });
@@ -64,11 +67,11 @@ describe(`${CoderWorkspacesCard.name}`, () => {
           readEntityData: value,
         });
 
-        const inputField = await screen.findByRole('searchbox', {
-          name: /Search your Coder workspaces/i,
+        const searchbox = await screen.findByRole('searchbox', {
+          name: matchers.searchbox,
         });
 
-        await user.tripleClick(inputField);
+        await user.tripleClick(searchbox);
         await user.keyboard('[Backspace]');
         await user.keyboard('I can do it - I can do it nine times');
 
@@ -93,12 +96,12 @@ describe(`${CoderWorkspacesCard.name}`, () => {
 
     it('Lets the user filter the workspaces by their query text', async () => {
       await renderWorkspacesCard({ readEntityData: false });
-      const inputField = await screen.findByRole('searchbox', {
-        name: /Search your Coder workspaces/i,
+      const searchbox = await screen.findByRole('searchbox', {
+        name: matchers.searchbox,
       });
 
       const user = userEvent.setup();
-      await user.tripleClick(inputField);
+      await user.tripleClick(searchbox);
       await user.keyboard(mockWorkspaceNoParameters.name);
 
       // If more than one workspace matches, that throws an error
@@ -108,12 +111,12 @@ describe(`${CoderWorkspacesCard.name}`, () => {
 
     it('Shows all workspaces when query text is empty', async () => {
       await renderWorkspacesCard({ readEntityData: false });
-      const inputField = await screen.findByRole('searchbox', {
-        name: /Search your Coder workspaces/i,
+      const searchbox = await screen.findByRole('searchbox', {
+        name: matchers.searchbox,
       });
 
       const user = userEvent.setup();
-      await user.tripleClick(inputField);
+      await user.tripleClick(searchbox);
       await user.keyboard('[Backspace]');
 
       const allWorkspaces = await screen.findAllByRole('listitem');
@@ -137,11 +140,11 @@ describe(`${CoderWorkspacesCard.name}`, () => {
       });
 
       const user = userEvent.setup();
-      const inputField = await screen.findByRole('searchbox', {
-        name: /Search your Coder workspaces/i,
+      const searchbox = await screen.findByRole('searchbox', {
+        name: matchers.searchbox,
       });
 
-      await user.tripleClick(inputField);
+      await user.tripleClick(searchbox);
       await user.keyboard(mockWorkspaceWithMatch2.name);
 
       await waitFor(() => {
@@ -162,16 +165,14 @@ describe(`${CoderWorkspacesCard.name}`, () => {
       await renderWorkspacesCard({ readEntityData: true });
 
       const user = userEvent.setup();
-      const inputField = await screen.findByRole('searchbox', {
-        name: /Search your Coder workspaces/i,
+      const searchbox = await screen.findByRole('searchbox', {
+        name: matchers.searchbox,
       });
 
-      await user.tripleClick(inputField);
+      await user.tripleClick(searchbox);
       await user.keyboard('[Backspace]');
 
-      const emptyState = await screen.findByText(
-        /Use the search bar to find matching Coder workspaces/,
-      );
+      const emptyState = await screen.findByText(matchers.emptyState);
 
       expect(emptyState).toBeInTheDocument();
     });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesList.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesList.test.tsx
@@ -3,7 +3,7 @@ import { type WorkspacesListProps, WorkspacesList } from './WorkspacesList';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
 import { CardContext, WorkspacesCardContext, WorkspacesQuery } from './Root';
 import { mockCoderWorkspacesConfig } from '../../testHelpers/mockBackstageData';
-import { mockWorkspace } from '../../testHelpers/mockCoderAppData';
+import { mockWorkspaceWithMatch } from '../../testHelpers/mockCoderAppData';
 import { Workspace } from '../../typesConstants';
 import { screen } from '@testing-library/react';
 
@@ -42,9 +42,9 @@ describe(`${WorkspacesList.name}`, () => {
     await renderWorkspacesList({
       workspacesQuery: {
         data: workspaceNames.map<Workspace>((name, index) => ({
-          ...mockWorkspace,
+          ...mockWorkspaceWithMatch,
           name,
-          id: `${mockWorkspace.id}-${index}`,
+          id: `${mockWorkspaceWithMatch.id}-${index}`,
         })),
       },
 

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesListItem.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesListItem.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
-import { mockWorkspace } from '../../testHelpers/mockCoderAppData';
+import { mockWorkspaceWithMatch } from '../../testHelpers/mockCoderAppData';
 import type { Workspace } from '../../typesConstants';
 import { WorkspacesListItem } from './WorkspacesListItem';
 
@@ -13,9 +13,9 @@ async function renderListItem(inputs?: RenderInput) {
   const { isOnline = true } = inputs ?? {};
 
   const workspace: Workspace = {
-    ...mockWorkspace,
+    ...mockWorkspaceWithMatch,
     latest_build: {
-      ...mockWorkspace.latest_build,
+      ...mockWorkspaceWithMatch.latest_build,
       status: isOnline ? 'running' : 'stopped',
       resources: [
         {

--- a/plugins/backstage-plugin-coder/src/hooks/useCoderWorkspacesQuery.test.ts
+++ b/plugins/backstage-plugin-coder/src/hooks/useCoderWorkspacesQuery.test.ts
@@ -3,6 +3,10 @@ import { useCoderWorkspacesQuery } from './useCoderWorkspacesQuery';
 
 import { renderHookAsCoderEntity } from '../testHelpers/setup';
 import { mockCoderWorkspacesConfig } from '../testHelpers/mockBackstageData';
+import {
+  mockWorkspaceNoParameters,
+  mockWorkspacesList,
+} from '../testHelpers/mockCoderAppData';
 
 beforeAll(() => {
   jest.useFakeTimers();
@@ -38,12 +42,22 @@ describe(`${useCoderWorkspacesQuery.name}`, () => {
     await jest.advanceTimersByTimeAsync(10_000);
   });
 
-  /* eslint-disable-next-line jest/no-disabled-tests --
-     Putting this off for the moment, because figuring out how to mock this out
-     without making the code fragile/flaky will probably take some time
-  */
-  it.skip('Will filter workspaces by search criteria when it is provided', async () => {
-    expect.hasAssertions();
+  it('Will filter workspaces by search criteria when it is provided', async () => {
+    const { result, rerender } = await renderHookAsCoderEntity(
+      ({ coderQuery }) => useCoderWorkspacesQuery({ coderQuery }),
+      { initialProps: { coderQuery: 'owner:me' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.length).toEqual(mockWorkspacesList.length);
+    });
+
+    rerender({ coderQuery: mockWorkspaceNoParameters.name });
+
+    await waitFor(() => {
+      const firstItemName = result.current.data?.[0]?.name;
+      expect(firstItemName).toBe(mockWorkspaceNoParameters.name);
+    });
   });
 
   it('Will only return workspaces for a given repo when a repoConfig is provided', async () => {
@@ -54,12 +68,7 @@ describe(`${useCoderWorkspacesQuery.name}`, () => {
       });
     });
 
-    // This query takes a little bit longer to run and process; waitFor will
-    // almost always give up too early if a longer timeout isn't specified
-    await waitFor(() => expect(result.current.status).toBe('success'), {
-      timeout: 3_000,
-    });
-
-    expect(result.current.data?.length).toBe(1);
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.data?.length).toBe(2);
   });
 });

--- a/plugins/backstage-plugin-coder/src/testHelpers/mockCoderAppData.ts
+++ b/plugins/backstage-plugin-coder/src/testHelpers/mockCoderAppData.ts
@@ -1,35 +1,85 @@
-import type {
-  Workspace,
-  WorkspaceAgent,
-  WorkspaceBuild,
-  WorkspaceBuildParameter,
-  WorkspaceResource,
-} from '../typesConstants';
+import type { Workspace, WorkspaceBuildParameter } from '../typesConstants';
+import { cleanedRepoUrl } from './mockBackstageData';
 
-export const mockWorkspaceAgent: WorkspaceAgent = {
-  id: 'test-workspace-agent',
-  status: 'connected',
-};
-
-export const mockWorkspaceResource: WorkspaceResource = {
-  id: 'test-workspace-resource',
-  agents: [mockWorkspaceAgent],
-};
-
-export const mockWorkspaceBuild: WorkspaceBuild = {
-  id: 'mock-workspace-build',
-  resources: [mockWorkspaceResource],
-  status: 'running',
-};
-
-export const mockWorkspace: Workspace = {
-  id: 'test-workspace',
+/**
+ * Mock for a workspace that matches the mock repo URL
+ */
+export const mockWorkspaceWithMatch: Workspace = {
+  id: 'workspace-with-match',
   name: 'Test-Workspace',
-  template_icon: '/emojis/apple.svg',
-
+  template_icon: '/emojis/dog.svg',
   owner_name: 'lil brudder',
+  latest_build: {
+    id: 'workspace-with-match-build',
+    status: 'running',
+    resources: [
+      {
+        id: 'workspace-with-match-resource',
+        agents: [{ id: 'test-workspace-agent', status: 'connected' }],
+      },
+    ],
+  },
+};
 
-  latest_build: mockWorkspaceBuild,
+export const mockWorkspaceNoMatch: Workspace = {
+  id: 'workspace-no-match',
+  name: 'No-match',
+  template_icon: '/emojis/star.svg',
+  owner_name: 'homestar runner',
+  latest_build: {
+    id: 'workspace-no-match-build',
+    status: 'stopped',
+    resources: [
+      {
+        id: 'workspace-no-match-resource',
+        agents: [
+          { id: 'test-workspace-agent-a', status: 'disconnected' },
+          { id: 'test-workspace-agent-b', status: 'timeout' },
+        ],
+      },
+    ],
+  },
+};
+
+export const mockWorkspaceNoParameters: Workspace = {
+  id: 'workspace-no-parameters',
+  name: 'No-parameters',
+  template_icon: '/emojis/cheese.png',
+  owner_name: 'The Cheat',
+  latest_build: {
+    id: 'workspace-no-parameters-build',
+    status: 'running',
+    resources: [
+      {
+        id: 'workspace-no-parameters-resource',
+        agents: [{ id: 'test-workspace-c', status: 'timeout' }],
+      },
+    ],
+  },
+};
+
+/**
+ * Contains a mix of different workspace variants
+ */
+export const mockWorkspacesList: Workspace[] = [
+  mockWorkspaceWithMatch,
+  mockWorkspaceNoMatch,
+  mockWorkspaceNoParameters,
+];
+
+export const mockWorkspaceBuildParameters: Record<
+  string,
+  readonly WorkspaceBuildParameter[]
+> = {
+  [mockWorkspaceWithMatch.latest_build.id]: [
+    { name: 'repo_url', value: cleanedRepoUrl },
+  ],
+  [mockWorkspaceNoMatch.latest_build.id]: [
+    { name: 'repo_url', value: 'https://www.github.com/wombo/zom' },
+  ],
+  [mockWorkspaceNoParameters.latest_build.id]: [
+    // Purposefully kept empty
+  ],
 };
 
 export const mockWorkspaceBuildParameter: WorkspaceBuildParameter = {

--- a/plugins/backstage-plugin-coder/src/testHelpers/mockCoderAppData.ts
+++ b/plugins/backstage-plugin-coder/src/testHelpers/mockCoderAppData.ts
@@ -21,6 +21,27 @@ export const mockWorkspaceWithMatch: Workspace = {
   },
 };
 
+export const mockWorkspaceWithMatch2: Workspace = {
+  id: 'workspace-with-match-2',
+  name: 'Another-Test',
+  template_icon: '/emojis/z.svg',
+  owner_name: 'Coach Z',
+  latest_build: {
+    id: 'workspace-with-match-2-build',
+    status: 'running',
+    resources: [
+      {
+        id: 'workspace-with-match-2-resource',
+        agents: [{ id: 'test-workspace-agent', status: 'connected' }],
+      },
+    ],
+  },
+};
+
+/**
+ * Mock for a workspace that has a repo URL, but the URL doesn't match the mock
+ * repo URL
+ */
 export const mockWorkspaceNoMatch: Workspace = {
   id: 'workspace-no-match',
   name: 'No-match',
@@ -41,6 +62,9 @@ export const mockWorkspaceNoMatch: Workspace = {
   },
 };
 
+/**
+ * A workspace with no build parameters whatsoever
+ */
 export const mockWorkspaceNoParameters: Workspace = {
   id: 'workspace-no-parameters',
   name: 'No-parameters',
@@ -63,6 +87,7 @@ export const mockWorkspaceNoParameters: Workspace = {
  */
 export const mockWorkspacesList: Workspace[] = [
   mockWorkspaceWithMatch,
+  mockWorkspaceWithMatch2,
   mockWorkspaceNoMatch,
   mockWorkspaceNoParameters,
 ];
@@ -74,11 +99,17 @@ export const mockWorkspaceBuildParameters: Record<
   [mockWorkspaceWithMatch.latest_build.id]: [
     { name: 'repo_url', value: cleanedRepoUrl },
   ],
+
+  [mockWorkspaceWithMatch2.latest_build.id]: [
+    { name: 'repo_url', value: cleanedRepoUrl },
+  ],
+
   [mockWorkspaceNoMatch.latest_build.id]: [
     { name: 'repo_url', value: 'https://www.github.com/wombo/zom' },
   ],
+
   [mockWorkspaceNoParameters.latest_build.id]: [
-    // Purposefully kept empty
+    // Intentionally kept empty
   ],
 };
 

--- a/plugins/backstage-plugin-coder/src/testHelpers/mockCoderAppData.ts
+++ b/plugins/backstage-plugin-coder/src/testHelpers/mockCoderAppData.ts
@@ -2,7 +2,7 @@ import type { Workspace, WorkspaceBuildParameter } from '../typesConstants';
 import { cleanedRepoUrl } from './mockBackstageData';
 
 /**
- * Mock for a workspace that matches the mock repo URL
+ * The main mock for a workspace that matches the mock repo URL
  */
 export const mockWorkspaceWithMatch: Workspace = {
   id: 'workspace-with-match',
@@ -21,6 +21,9 @@ export const mockWorkspaceWithMatch: Workspace = {
   },
 };
 
+/**
+ * A secondary mock for a workspace that matches the mock repo URL
+ */
 export const mockWorkspaceWithMatch2: Workspace = {
   id: 'workspace-with-match-2',
   name: 'Another-Test',

--- a/plugins/backstage-plugin-coder/src/testHelpers/mockCoderAppData.ts
+++ b/plugins/backstage-plugin-coder/src/testHelpers/mockCoderAppData.ts
@@ -2,7 +2,7 @@ import type { Workspace, WorkspaceBuildParameter } from '../typesConstants';
 import { cleanedRepoUrl } from './mockBackstageData';
 
 /**
- * The main mock for a workspace that matches the mock repo URL
+ * The main mock for a workspace whose repo URL matches cleanedRepoUrl
  */
 export const mockWorkspaceWithMatch: Workspace = {
   id: 'workspace-with-match',
@@ -22,7 +22,10 @@ export const mockWorkspaceWithMatch: Workspace = {
 };
 
 /**
- * A secondary mock for a workspace that matches the mock repo URL
+ * A secondary mock for a workspace whose repo URL matches cleanedRepoUrl.
+ *
+ * Mainly here for asserting that things like search functionality are able to
+ * return multiple values back
  */
 export const mockWorkspaceWithMatch2: Workspace = {
   id: 'workspace-with-match-2',
@@ -42,8 +45,8 @@ export const mockWorkspaceWithMatch2: Workspace = {
 };
 
 /**
- * Mock for a workspace that has a repo URL, but the URL doesn't match the mock
- * repo URL
+ * Mock for a workspace that has a repo URL, but the URL doesn't match
+ * cleanedRepoUrl
  */
 export const mockWorkspaceNoMatch: Workspace = {
   id: 'workspace-no-match',
@@ -114,9 +117,4 @@ export const mockWorkspaceBuildParameters: Record<
   [mockWorkspaceNoParameters.latest_build.id]: [
     // Intentionally kept empty
   ],
-};
-
-export const mockWorkspaceBuildParameter: WorkspaceBuildParameter = {
-  name: 'goofy',
-  value: 'a-hyuck',
 };

--- a/plugins/backstage-plugin-coder/src/testHelpers/server.ts
+++ b/plugins/backstage-plugin-coder/src/testHelpers/server.ts
@@ -11,16 +11,27 @@ import {
   mockCoderAuthToken,
   mockBackstageProxyEndpoint as root,
 } from './mockBackstageData';
-import type { WorkspacesResponse } from '../typesConstants';
+import type { Workspace, WorkspacesResponse } from '../typesConstants';
 import { CODER_AUTH_HEADER_KEY } from '../api';
 
 const handlers: readonly RestHandler[] = [
-  rest.get(`${root}/workspaces`, (_, res, ctx) => {
+  rest.get(`${root}/workspaces`, (req, res, ctx) => {
+    const queryText = String(req.url.searchParams.get('q'));
+
+    let returnedWorkspaces: Workspace[];
+    if (queryText === 'owner:me') {
+      returnedWorkspaces = mockWorkspacesList;
+    } else {
+      returnedWorkspaces = mockWorkspacesList.filter(ws =>
+        ws.name.includes(queryText),
+      );
+    }
+
     return res(
       ctx.status(200),
       ctx.json<WorkspacesResponse>({
-        workspaces: mockWorkspacesList,
-        count: mockWorkspacesList.length,
+        workspaces: returnedWorkspaces,
+        count: returnedWorkspaces.length,
       }),
     );
   }),

--- a/plugins/backstage-plugin-coder/src/testHelpers/server.ts
+++ b/plugins/backstage-plugin-coder/src/testHelpers/server.ts
@@ -4,47 +4,23 @@ import { setupServer } from 'msw/node';
 /* eslint-enable @backstage/no-undeclared-imports */
 
 import {
-  mockWorkspace,
-  mockWorkspaceBuild,
-  mockWorkspaceBuildParameter,
+  mockWorkspacesList,
+  mockWorkspaceBuildParameters,
 } from './mockCoderAppData';
 import {
-  cleanedRepoUrl,
   mockCoderAuthToken,
   mockBackstageProxyEndpoint as root,
 } from './mockBackstageData';
-import {
-  WorkspaceBuildParameter,
-  type Workspace,
-  WorkspacesResponse,
-} from '../typesConstants';
+import type { WorkspacesResponse } from '../typesConstants';
 import { CODER_AUTH_HEADER_KEY } from '../api';
-
-const repoBuildParamId = 'mock-repo';
 
 const handlers: readonly RestHandler[] = [
   rest.get(`${root}/workspaces`, (_, res, ctx) => {
-    const sampleWorkspaces = new Array<Workspace>(5)
-      .fill(mockWorkspace)
-      .map<Workspace>((ws, i) => {
-        const oneIndexed = i + 1;
-
-        return {
-          ...ws,
-          id: `${ws.id}-${oneIndexed}`,
-          name: `${ws.name}-${oneIndexed}`,
-          latest_build: {
-            ...mockWorkspaceBuild,
-            id: i === 0 ? repoBuildParamId : `${ws.name}-${oneIndexed}`,
-          },
-        };
-      });
-
     return res(
       ctx.status(200),
       ctx.json<WorkspacesResponse>({
-        workspaces: sampleWorkspaces,
-        count: sampleWorkspaces.length,
+        workspaces: mockWorkspacesList,
+        count: mockWorkspacesList.length,
       }),
     );
   }),
@@ -52,25 +28,14 @@ const handlers: readonly RestHandler[] = [
   rest.get(
     `${root}/workspacebuilds/:workspaceBuildId/parameters`,
     (req, res, ctx) => {
-      const workspaceBuildId = (req.params.workspaceBuildId ?? '') as string;
+      const buildId = String(req.params.workspaceBuildId);
+      const selectedParams = mockWorkspaceBuildParameters[buildId];
 
-      const sampleBuildParams = new Array<WorkspaceBuildParameter>(5)
-        .fill(mockWorkspaceBuildParameter)
-        .map<WorkspaceBuildParameter>((wbp, i) => {
-          const oneIndexed = i + 1;
-          const useRepoName = i === 0 && workspaceBuildId === repoBuildParamId;
+      if (selectedParams !== undefined) {
+        return res(ctx.status(200), ctx.json(selectedParams));
+      }
 
-          return {
-            ...wbp,
-            name: useRepoName ? 'repo_url' : `${wbp.value}-${oneIndexed}`,
-            value: useRepoName ? cleanedRepoUrl : `${wbp.value}-${oneIndexed}`,
-          };
-        });
-
-      return res(
-        ctx.status(200),
-        ctx.json<readonly WorkspaceBuildParameter[]>(sampleBuildParams),
-      );
+      return res(ctx.status(404));
     },
   ),
 


### PR DESCRIPTION
Closes #8 

## Changes made
- Added integration test for `CoderWorkspacesCard`
   - It basically tests all the sub-components when wired together
- Filled in stub test for `useCoderWorkspacesQuery`
- Updated how mock data was defined, and changed how the MSW handlers were returning data

## Notes
There is one more behavior that could use a test, but I'm not sure if it's worth it. Basic steps are:
   1. Log into the Coder deployment with user account 1
   2. Log into Backstage
   3. Get the auth token for user account 1, and insert it
   4. Go back to the Coder deployment, log out, and then log in with user account 2
   5. Expect that the workspaces for user account 1 no longer appear

I was running into this when I was logged into the Full-stack challenge account, but had a token loaded for my personal Coder account. I think there is a way to simulate this at least, but:
1. I don't know if it's 100% reliable and would give us that much confidence
2. I don't know if this edge case is too niche to warrant complicating some of the testing setup