### PR TITLE
chore(coder plugin): make template names optional

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -137,8 +137,8 @@ const coderAppConfig: CoderAppConfig = {
   },
 
   workspaces: {
-    templateName: 'devcontainers',
-    mode: 'manual',
+    defaultTemplateName: 'devcontainers',
+    defaultMode: 'manual',
     repoUrlParamKeys: ['custom_repo', 'repo_url'],
     params: {
       repo: 'custom',

--- a/plugins/backstage-plugin-coder/README.md
+++ b/plugins/backstage-plugin-coder/README.md
@@ -28,22 +28,23 @@ the Dev Container.
    yarn --cwd packages/app add @coder/backstage-plugin-coder
    ```
 
-1. Add the proxy key to your `app-config.yaml`:
+2. Add the proxy key to your `app-config.yaml`:
 
    ```yaml
    proxy:
      endpoints:
        '/coder':
-         # Replace with your Coder deployment access URL and a trailing /
+         # Replace with your Coder deployment access URL (add a trailing slash)
          target: 'https://coder.example.com/'
+
          changeOrigin: true
-         allowedMethods: ['GET']
+         allowedMethods: ['GET'] # Additional methods will be supported soon!
          allowedHeaders: ['Authorization', 'Coder-Session-Token']
          headers:
            X-Custom-Source: backstage
    ```
 
-1. Add the `CoderProvider` to the application:
+3. Add the `CoderProvider` to the application:
 
    ```tsx
    // In packages/app/src/App.tsx
@@ -58,14 +59,16 @@ the Dev Container.
      },
 
      // Set the default template (and parameters) for
-     // catalog items. This can be overridden in the
-     // catalog-info.yaml for specific items.
+     // catalog items. Individual properties can be overridden
+     // by a repo's catalog-info.yaml file
      workspaces: {
-       templateName: 'devcontainers',
-       mode: 'manual',
-       // This parameter is used to filter Coder workspaces
-       // by a repo URL parameter.
+       defaultTemplateName: 'devcontainers',
+       defaultMode: 'manual',
+
+       // This property defines which parameters in your Coder
+       // workspace templates are used to store repository links
        repoUrlParamKeys: ['custom_repo', 'repo_url'],
+
        params: {
          repo: 'custom',
          region: 'eu-helsinki',
@@ -88,7 +91,7 @@ the Dev Container.
 
    **Note:** You can also wrap a single page or component with `CoderProvider` if you only need Coder in a specific part of your app. See our [API reference](./docs/README.md) (particularly the section on [the `CoderProvider` component](./docs/components.md#coderprovider)) for more details.
 
-1. Add the `CoderWorkspacesCard` card to the entity page in your app:
+4. Add the `CoderWorkspacesCard` card to the entity page in your app:
 
    ```tsx
    // In packages/app/src/components/catalog/EntityPage.tsx
@@ -100,6 +103,33 @@ the Dev Container.
      <CoderWorkspacesCard readEntityData />
    </Grid>;
    ```
+
+### `app-config.yaml` files
+
+In addition to the above, you can define additional properties on your specific repo's `catalog-info.yaml` file.
+
+Example:
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: python-project
+spec:
+  type: other
+  lifecycle: unknown
+  owner: pms
+
+  # Properties for the Coder plugin are placed here
+  coder:
+    templateName: 'devcontainers'
+    mode: 'auto'
+    params:
+      repo: 'custom'
+      region: 'us-pittsburgh'
+```
+
+You can find more information about what properties are available (and how they're applied) in our [`catalog-info.yaml` file documentation](./docs/catalog-info.md).
 
 ## Roadmap
 

--- a/plugins/backstage-plugin-coder/dev/DevPage.tsx
+++ b/plugins/backstage-plugin-coder/dev/DevPage.tsx
@@ -24,8 +24,8 @@ const appConfig: CoderAppConfig = {
   },
 
   workspaces: {
-    templateName: 'devcontainers',
-    mode: 'manual',
+    defaultTemplateName: 'devcontainers',
+    defaultMode: 'manual',
     repoUrlParamKeys: ['custom_repo', 'repo_url'],
     params: {
       repo: 'custom',

--- a/plugins/backstage-plugin-coder/docs/catalog-info.md
+++ b/plugins/backstage-plugin-coder/docs/catalog-info.md
@@ -1,0 +1,59 @@
+# `catalog-info.yaml` files
+
+This file provides documentation for all properties that the Coder plugin recognizes from Backstage's [`catalog-info.yaml` files](https://backstage.io/docs/features/software-catalog/descriptor-format/).
+
+## Example file
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: python-project
+spec:
+  type: other
+  lifecycle: unknown
+  owner: pms
+
+  # Properties for the Coder plugin are placed here
+  coder:
+    templateName: 'devcontainers'
+    mode: 'auto'
+    params:
+      repo: 'custom'
+      region: 'us-pittsburgh'
+```
+
+All config properties are placed under the `spec.coder` property.
+
+## Where these properties are used
+
+At present, there are two main areas where these values are used:
+
+- [`CoderWorkspacesCard`](./components.md#coderworkspacescard) (and all sub-components)
+- [`useCoderWorkspacesConfig`](./hooks.md#usecoderworkspacesconfig)
+
+## Property listing
+
+### `templateName`
+
+**Type:** Optional `string`
+
+This defines the name of the Coder template you would like to use when creating new workspaces from Backstage.
+
+**Note:** This value has overlap with the `defaultTemplateName` property defined in [`CoderAppConfig`](types.md#coderappconfig). In the event that both values are present, the YAML file's `templateName` property will always be used instead.
+
+### `templateName`
+
+**Type:** Optional union of `manual` or `auto`
+
+This defines the workspace creation mode that will be embedded as a URL parameter in any outgoing links to make new workspaces in your Coder deployment. (e.g.,`useCoderWorkspacesConfig`'s `creationUrl` property)
+
+**Note:** This value has overlap with the `defaultMode` property defined in [`CoderAppConfig`](types.md#coderappconfig). In the event that both values are present, the YAML file's `mode` property will always be used instead.
+
+### `params`
+
+**Type:** Optional JSON object of string values (equivalent to TypeScript's `Record<string, string | undefined>`)
+
+This allows you to define additional Coder workspace parameter values that should be passed along to any outgoing URLs for making new workspaces in your Coder deployment. These values are fully dynamic, and unfortunately, cannot have much type safety.
+
+**Note:** The properties from the `params` property are automatically merged with the properties defined via `CoderAppConfig`'s `params` property. In the event of any key conflicts, the params from `catalog-info.yaml` will always win.

--- a/plugins/backstage-plugin-coder/docs/components.md
+++ b/plugins/backstage-plugin-coder/docs/components.md
@@ -544,3 +544,26 @@ declare function WorkspaceListItem(props: Props): JSX.Element;
 ### Notes
 
 - Supports full link-like functionality (right-clicking and middle-clicking to open in a new tab, etc.)
+
+## `CoderWorkspacesCard.ReminderAccordion`
+
+An accordion that will conditionally display additional help information in the event of a likely setup error.
+
+### Type definition
+
+```tsx
+type ReminderAccordionProps = Readonly<{
+  canShowEntityReminder?: boolean;
+  canShowTemplateNameReminder?: boolean;
+}>;
+
+declare function ReminderAccordion(props: ReminderAccordionProps): JSX.Element;
+```
+
+### Throws
+
+- Will throw a render error if mounted outside of `CoderWorkspacesCard.Root` or `CoderProvider`.
+
+### Notes
+
+- All `canShow` props allow you to disable specific help messages. If any are set to `false`, their corresponding info block will **never** render. If set to `true` (and all will default to `true` if not specified), they will only appear when a likely setup error has been detected.

--- a/plugins/backstage-plugin-coder/docs/hooks.md
+++ b/plugins/backstage-plugin-coder/docs/hooks.md
@@ -30,7 +30,7 @@ declare function useCoderWorkspacesConfig(
 
 ```tsx
 function YourComponent() {
-  const config = useCoderWorkspacesConfig();
+  const config = useCoderWorkspacesConfig({ readEntityData: true });
   return <p>Your repo URL is {config.repoUrl}</p>;
 }
 
@@ -62,14 +62,14 @@ const serviceEntityPage = (
 
 ### Notes
 
-- The type definition for `CoderWorkspacesConfig` [can be found here](./types.md#coderworkspacesconfig). That section also includes info on the heuristic used for compiling the data
+- The type definition for `CoderWorkspacesConfig` [can be found here](./types.md#coderworkspacesconfig). That section also includes info on the heuristic used for compiling the data.
 - The value of `readEntityData` determines the "mode" that the workspace operates in. If the value is `false`/`undefined`, the component will act as a general list of workspaces that isn't aware of Backstage APIs. If the value is `true`, the hook will also read Backstage data during the compilation step.
 - The hook tries to ensure that the returned value maintains a stable memory reference as much as possible, if you ever need to use that value in other React hooks that use dependency arrays (e.g., `useEffect`, `useCallback`)
 
 ## `useCoderWorkspacesQuery`
 
 This hook gives you access to all workspaces that match a given query string. If
-[`workspacesConfig`](#usecoderworkspacesconfig) is defined via `options`, and that config has a defined `repoUrl`, the workspaces returned will be filtered down further to only those that match the the repo.
+[`workspacesConfig`](#usecoderworkspacesconfig) is defined via `options`, and that config has a defined `repoUrl` property, the workspaces returned will be filtered down further to only those that match the the repo.
 
 ### Type signature
 
@@ -88,9 +88,9 @@ declare function useCoderWorkspacesConfig(
 
 ```tsx
 function YourComponent() {
-  const [filter, setFilter] = useState('owner:me');
+  const [coderQuery, setCoderQuery] = useState('owner:me');
   const workspacesConfig = useCoderWorkspacesConfig({ readEntityData: true });
-  const queryState = useCoderWorkspacesQuery({ filter, workspacesConfig });
+  const queryState = useCoderWorkspacesQuery({ coderQuery, workspacesConfig });
 
   return (
     <>
@@ -130,7 +130,7 @@ const coderAppConfig: CoderAppConfig = {
   1.  The user is not currently authenticated (We recommend wrapping your component inside [`CoderAuthWrapper`](./components.md#coderauthwrapper) to make these checks easier)
   2.  If `repoConfig` is passed in via `options`: when the value of `coderQuery` is an empty string
 - The `workspacesConfig` property is the return type of [`useCoderWorkspacesConfig`](#usecoderworkspacesconfig)
-  - The only way to get automatically-filtered results is by (1) passing in a workspaces config value, and (2) ensuring that config has a `repoUrl` property of type string (it can sometimes be `undefined`, depending on built-in Backstage APIs).
+  - The only way to get workspace results that are automatically filtered by repo URL is by (1) passing in a workspaces config value, and (2) ensuring that config has a `repoUrl` property of type string (it can sometimes be `undefined`, depending on built-in Backstage APIs).
 
 ## `useWorkspacesCardContext`
 

--- a/plugins/backstage-plugin-coder/docs/types.md
+++ b/plugins/backstage-plugin-coder/docs/types.md
@@ -2,7 +2,7 @@
 
 ## General notes
 
-- All type definitions for the Coder plugin are defined as type aliases and not interfaces, to prevent the risk of accidental interface merging. If you need to extend from one of our types, you can do it in one of two ways:
+- All exported type definitions for the Coder plugin are defined as type aliases and not interfaces, to prevent the risk of accidental interface merging. If you need to extend from one of our types, you can do it in one of two ways:
 
   ```tsx
   // Type intersection
@@ -28,15 +28,15 @@
 Defines a set of configuration options for integrating Backstage with Coder. Primarily has two main uses:
 
 1. Defining a centralized source of truth for certain Coder configuration options (such as which workspace parameters should be used for injecting repo URL values)
-2. Defining "fallback" workspace parameters when a repository entity either doesn't have a `catalog-info.yaml` file at all, or only specifies a handful of properties.
+2. Defining "fallback" workspace parameters when a repository entity either doesn't have a [`catalog-info.yaml` file](./catalog-info.md) at all, or only specifies a handful of properties.
 
 ### Type definition
 
 ```tsx
 type CoderAppConfig = Readonly<{
   workspaces: Readonly<{
-    templateName: string;
-    mode?: 'auto' | 'manual' | undefined;
+    defaultTemplateName?: string;
+    defaultMode?: 'auto' | 'manual' | undefined;
     params?: Record<string, string | undefined>;
     repoUrlParamKeys: readonly [string, ...string[]];
   }>;
@@ -54,10 +54,10 @@ See example for [`CoderProvider`](./components.md#coderprovider)
 ### Notes
 
 - `accessUrl` is the URL pointing at your specific Coder deployment
-- `templateName` refers to the name of the Coder template that you wish to use as default for creating workspaces
-- If `mode` is not specified, the plugin will default to a value of `manual`
+- `defaultTemplateName` refers to the name of the Coder template that you wish to use as default for creating workspaces. If this is not provided (and there is no `templateName` available from the `catalog-info.yaml` file, you will not be able to create new workspaces from Backstage)
+- If `defaultMode` is not specified, the plugin will default to a value of `manual`
 - `repoUrlParamKeys` is defined as a non-empty array – there must be at least one element inside it.
-- For more info on how this type is used within the plugin, see [`CoderWorkspacesConfig`](./types.md#coderworkspacesconfig) and [`useCoderWorkspacesConfig`](./hooks.md#usecoderworkspacesconfig)
+- For more info on how this type is used within the plugin, see [`CoderWorkspacesConfig`](#coderworkspacesconfig) and [`useCoderWorkspacesConfig`](./hooks.md#usecoderworkspacesconfig)
 
 ## `CoderWorkspacesConfig`
 
@@ -72,11 +72,11 @@ Represents the result of compiling Coder plugin configuration data. The main sou
 ```tsx
 type CoderWorkspacesConfig = Readonly<{
   mode: 'manual' | 'auto';
+  templateName: string | undefined;
   params: Record<string, string | undefined>;
   creationUrl: string;
   repoUrl: string | undefined;
   repoUrlParamKeys: [string, ...string[]][];
-  templateName: string;
 }>;
 ```
 
@@ -91,8 +91,8 @@ const appConfig: CoderAppConfig = {
   },
 
   workspaces: {
-    templateName: 'devcontainers-a',
-    mode: 'manual',
+    defaultTemplateName: 'devcontainers-config',
+    defaultMode: 'manual',
     repoUrlParamKeys: ['custom_repo', 'repo_url'],
     params: {
       repo: 'custom',
@@ -113,7 +113,7 @@ spec:
   lifecycle: unknown
   owner: pms
   coder:
-    templateName: 'devcontainers-b'
+    templateName: 'devcontainers-yaml'
     mode: 'auto'
     params:
       repo: 'custom'
@@ -132,13 +132,13 @@ const config: CoderWorkspacesConfig = {
     repo_url: 'https://github.com/Parkreiner/python-project/',
   },
   repoUrlParamKeys: ['custom_repo', 'repo_url'],
-  templateName: 'devcontainers',
+  templateName: 'devcontainers-yaml',
   repoUrl: 'https://github.com/Parkreiner/python-project/',
 
   // Other URL parameters will be included in real code
   // but were stripped out for this example
   creationUrl:
-    'https://dev.coder.com/templates/devcontainers-b/workspace?mode=auto',
+    'https://dev.coder.com/templates/devcontainers-yaml/workspace?mode=auto',
 };
 ```
 
@@ -148,7 +148,7 @@ const config: CoderWorkspacesConfig = {
 - The value of the `repoUrl` property is derived from [Backstage's `getEntitySourceLocation`](https://backstage.io/docs/reference/plugin-catalog-react.getentitysourcelocation/), which does not guarantee that a URL will always be defined.
 - This is the current order of operations used to reconcile param data between `CoderAppConfig`, `catalog-info.yaml`, and the entity location data:
   1. Start with an empty `Record<string, string | undefined>` value
-  2. Populate the record with the data from `CoderAppConfig`
+  2. Populate the record with the data from `CoderAppConfig`. If there are any property names that start with `default`, those will be stripped out (e.g., `defaultTemplateName` will be injected as `templateName`)
   3. Go through all properties parsed from `catalog-info.yaml` and inject those. If the properties are already defined, overwrite them
   4. Grab the repo URL from the entity's location fields.
   5. For each key in `CoderAppConfig`'s `workspaces.repoUrlParamKeys` property, take that key, and inject it as a key-value pair, using the URL as the value. If the key already exists, always override it with the URL

--- a/plugins/backstage-plugin-coder/src/components/AccordionItem/AccordionItem.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/AccordionItem/AccordionItem.test.tsx
@@ -2,20 +2,20 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
-import { Root } from './Root';
-import { ReminderAccordionItem } from './ReminderAccordionItem';
+import { Root } from '../CoderWorkspacesCard/Root';
+import { AccordionItem } from './AccordionItem';
 
 function render() {
   return renderInCoderEnvironment({
     children: (
       <Root>
-        <ReminderAccordionItem />
+        <AccordionItem />
       </Root>
     ),
   });
 }
 
-describe(`${ReminderAccordionItem.name}`, () => {
+describe(`${AccordionItem.name}`, () => {
   it('Will toggle between showing/hiding the disclosure info when the user clicks it', async () => {
     await render();
     const user = userEvent.setup();

--- a/plugins/backstage-plugin-coder/src/components/AccordionItem/AccordionItem.tsx
+++ b/plugins/backstage-plugin-coder/src/components/AccordionItem/AccordionItem.tsx
@@ -42,14 +42,13 @@ type AccordionItemProps = Readonly<
   }>
 >;
 
-export const ReminderAccordionItem = ({
+export const AccordionItem = ({
   isExpanded,
   onExpansion,
   headerText,
   children,
 }: AccordionItemProps) => {
   const styles = useStyles();
-
   const hookId = useId();
   const disclosureBodyId = `${hookId}-disclosure-body`;
 

--- a/plugins/backstage-plugin-coder/src/components/CoderAuthWrapper/CoderAuthWrapper.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderAuthWrapper/CoderAuthWrapper.test.tsx
@@ -166,8 +166,6 @@ describe(`${CoderAuthWrapper.name}`, () => {
 
         unmount();
       }
-
-      expect.hasAssertions();
     });
 
     it('Lets the user submit a new token', async () => {

--- a/plugins/backstage-plugin-coder/src/components/CoderErrorBoundary/CoderErrorBoundary.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderErrorBoundary/CoderErrorBoundary.test.tsx
@@ -47,8 +47,8 @@ function setupBoundaryTest(component: ReactElement) {
 describe(`${CoderErrorBoundary.name}`, () => {
   it('Displays a fallback UI when a rendering error is encountered', () => {
     setupBoundaryTest(<BrokenComponent />);
-    screen.getByText(fallbackText);
-    expect.hasAssertions();
+    const fallbackUi = screen.getByText(fallbackText);
+    expect(fallbackUi).toBeInTheDocument();
   });
 
   it('Exposes rendering errors to Backstage Error API', () => {

--- a/plugins/backstage-plugin-coder/src/components/CoderProvider/CoderAppConfigProvider.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderProvider/CoderAppConfigProvider.tsx
@@ -3,23 +3,24 @@ import React, {
   createContext,
   useContext,
 } from 'react';
-
-import type { YamlConfig } from '../../hooks/useCoderWorkspacesConfig';
+import type { WorkspaceCreationMode } from '../../hooks/useCoderWorkspacesConfig';
 
 export type CoderAppConfig = Readonly<{
   deployment: Readonly<{
     accessUrl: string;
   }>;
 
-  workspaces: Readonly<
-    Exclude<YamlConfig, undefined> & {
-      // Only specified explicitly to make templateName required
-      templateName: string;
+  // Type is meant to be used with YamlConfig from useCoderWorkspacesConfig;
+  // not using a mapped type because there's just enough differences that
+  // maintaining a relationship that way would be a nightmare of ternaries
+  workspaces: Readonly<{
+    defaultMode?: WorkspaceCreationMode;
+    defaultTemplateName?: string;
+    params?: Record<string, string | undefined>;
 
-      // Defined like this to ensure array always has at least one element
-      repoUrlParamKeys: readonly [string, ...string[]];
-    }
-  >;
+    // Defined like this to ensure array always has at least one element
+    repoUrlParamKeys: readonly [string, ...string[]];
+  }>;
 }>;
 
 const AppConfigContext = createContext<CoderAppConfig | null>(null);

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CoderWorkspacesCard.tsx
@@ -7,6 +7,7 @@ import { SearchBox } from './SearchBox';
 import { WorkspacesList } from './WorkspacesList';
 import { CreateWorkspaceLink } from './CreateWorkspaceLink';
 import { ExtraActionsButton } from './ExtraActionsButton';
+import { ReminderAccordion } from './ReminderAccordion';
 
 const useStyles = makeStyles(theme => ({
   searchWrapper: {
@@ -15,9 +16,9 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export const CoderWorkspacesCard = (
-  props: Omit<WorkspacesCardProps, 'children'>,
-) => {
+type Props = Omit<WorkspacesCardProps, 'children' | 'footerContent'>;
+
+export const CoderWorkspacesCard = (props: Props) => {
   const styles = useStyles();
 
   return (
@@ -37,6 +38,7 @@ export const CoderWorkspacesCard = (
       </div>
 
       <WorkspacesList />
+      <ReminderAccordion />
     </Root>
   );
 };

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.test.tsx
@@ -1,17 +1,43 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockAppConfig } from '../../testHelpers/mockBackstageData';
+import {
+  mockAppConfig,
+  mockCoderWorkspacesConfig,
+} from '../../testHelpers/mockBackstageData';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
-import { Root } from './Root';
+import { CardContext, WorkspacesCardContext } from './Root';
 import { CreateWorkspaceLink } from './CreateWorkspaceLink';
+import type { CoderWorkspacesConfig } from '../../hooks/useCoderWorkspacesConfig';
 
-function render() {
+type RenderInputs = Readonly<{
+  hasTemplateName?: boolean;
+}>;
+
+function render(inputs?: RenderInputs) {
+  const { hasTemplateName = true } = inputs ?? {};
+
+  const mockWorkspacesConfig: CoderWorkspacesConfig = {
+    ...mockCoderWorkspacesConfig,
+    creationUrl: hasTemplateName
+      ? mockCoderWorkspacesConfig.creationUrl
+      : undefined,
+  };
+
+  const mockContextValue: WorkspacesCardContext = {
+    workspacesConfig: mockWorkspacesConfig,
+    headerId: "Doesn't matter",
+    queryFilter: "Also doesn't matter",
+    onFilterChange: jest.fn(),
+    workspacesQuery:
+      null as unknown as WorkspacesCardContext['workspacesQuery'],
+  };
+
   return renderInCoderEnvironment({
     children: (
-      <Root>
+      <CardContext.Provider value={mockContextValue}>
         <CreateWorkspaceLink />
-      </Root>
+      </CardContext.Provider>
     ),
   });
 }
@@ -35,6 +61,27 @@ describe(`${CreateWorkspaceLink.name}`, () => {
 
     await user.hover(link);
     const tooltip = await screen.findByText('Add a new workspace');
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it('Will be disabled and will indicate to the user when there is no usable templateName value', async () => {
+    await render({ hasTemplateName: false });
+    const link = screen.getByRole<HTMLAnchorElement>('link');
+
+    // Check that the link is "disabled" properly (see main component file for
+    // a link to resource explaining edge cases). Can't assert toBeDisabled,
+    // because links don't support the disabled attribute; also can't check
+    // the .role and .ariaDisabled properties on the link variable, because even
+    // though they exist in the output, RTL doesn't correctly pass them through.
+    // This is a niche edge case - have to check properties on the raw HTML node
+    expect(link.href).toBe('');
+    expect(link.getAttribute('role')).toBe('link');
+    expect(link.getAttribute('aria-disabled')).toBe('true');
+
+    // Make sure tooltip is also updated
+    const user = userEvent.setup();
+    await user.hover(link);
+    const tooltip = await screen.findByText('Please add a template name value');
     expect(tooltip).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.test.tsx
@@ -26,6 +26,9 @@ function render(inputs?: RenderInputs) {
 
   const mockContextValue: WorkspacesCardContext = {
     workspacesConfig: mockWorkspacesConfig,
+
+    // Everything below this comment doesn't matter for the test logic
+    readEntityData: false,
     headerId: "Doesn't matter",
     queryFilter: "Also doesn't matter",
     onFilterChange: jest.fn(),

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.test.tsx
@@ -24,21 +24,13 @@ function render(inputs?: RenderInputs) {
       : undefined,
   };
 
-  const mockContextValue: WorkspacesCardContext = {
+  const mockContextValue: Partial<WorkspacesCardContext> = {
     workspacesConfig: mockWorkspacesConfig,
-
-    // Everything below this comment doesn't matter for the test logic
-    isReadingEntityData: false,
-    headerId: "Doesn't matter",
-    queryFilter: "Also doesn't matter",
-    onFilterChange: jest.fn(),
-    workspacesQuery:
-      null as unknown as WorkspacesCardContext['workspacesQuery'],
   };
 
   return renderInCoderEnvironment({
     children: (
-      <CardContext.Provider value={mockContextValue}>
+      <CardContext.Provider value={mockContextValue as WorkspacesCardContext}>
         <CreateWorkspaceLink />
       </CardContext.Provider>
     ),

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.test.tsx
@@ -28,7 +28,7 @@ function render(inputs?: RenderInputs) {
     workspacesConfig: mockWorkspacesConfig,
 
     // Everything below this comment doesn't matter for the test logic
-    readEntityData: false,
+    isReadingEntityData: false,
     headerId: "Doesn't matter",
     queryFilter: "Also doesn't matter",
     onFilterChange: jest.fn(),

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.test.tsx
@@ -76,7 +76,7 @@ describe(`${CreateWorkspaceLink.name}`, () => {
     // Make sure tooltip is also updated
     const user = userEvent.setup();
     await user.hover(link);
-    const tooltip = await screen.findByText('Please add a template name value');
+    const tooltip = await screen.findByText(/Please add a template name value/);
     expect(tooltip).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.tsx
@@ -70,8 +70,9 @@ export const CreateWorkspaceLink = ({
     >
       {/* eslint-disable-next-line jsx-a11y/no-redundant-roles --
           Some browsers will render out <a> elements as having no role when the
-          href value is undefined. Need to make sure that the link role is
-          always defined, no matter what. The ESLint rule is wrong here. */}
+          href value is undefined or an empty string. Need to make sure that the
+          link role is always defined, no matter what. The ESLint rule is wrong
+          here. */}
       <a
         role="link"
         target={target}

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.tsx
@@ -10,8 +10,7 @@ type StyleInput = Readonly<{
   canCreateWorkspace: boolean;
 }>;
 
-type StyleKeys = 'root' | 'icon';
-
+type StyleKeys = 'root';
 const useStyles = makeStyles<Theme, StyleInput, StyleKeys>(theme => {
   const padding = theme.spacing(0.5);
 
@@ -20,19 +19,23 @@ const useStyles = makeStyles<Theme, StyleInput, StyleKeys>(theme => {
       padding,
       width: theme.spacing(4) + padding,
       height: theme.spacing(4) + padding,
+      cursor: 'pointer',
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
       backgroundColor: 'inherit',
       borderRadius: '9999px',
       lineHeight: 1,
+      color: canCreateWorkspace
+        ? theme.palette.text.primary
+        : theme.palette.text.disabled,
 
       '&:hover': {
-        backgroundColor: theme.palette.action.hover,
+        backgroundColor: canCreateWorkspace
+          ? theme.palette.action.hover
+          : 'inherit',
       },
     }),
-
-    icon: {},
   };
 });
 

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.tsx
@@ -1,16 +1,22 @@
 import React, { type AnchorHTMLAttributes, type ForwardedRef } from 'react';
-import { makeStyles } from '@material-ui/core';
+import { type Theme, makeStyles } from '@material-ui/core';
 import { useWorkspacesCardContext } from './Root';
 
 import { VisuallyHidden } from '../VisuallyHidden';
 import AddIcon from '@material-ui/icons/AddCircleOutline';
 import Tooltip, { type TooltipProps } from '@material-ui/core/Tooltip';
 
-const useStyles = makeStyles(theme => {
+type StyleInput = Readonly<{
+  canCreateWorkspace: boolean;
+}>;
+
+type StyleKeys = 'root' | 'icon';
+
+const useStyles = makeStyles<Theme, StyleInput, StyleKeys>(theme => {
   const padding = theme.spacing(0.5);
 
   return {
-    root: {
+    root: ({ canCreateWorkspace }) => ({
       padding,
       width: theme.spacing(4) + padding,
       height: theme.spacing(4) + padding,
@@ -24,12 +30,14 @@ const useStyles = makeStyles(theme => {
       '&:hover': {
         backgroundColor: theme.palette.action.hover,
       },
-    },
+    }),
+
+    icon: {},
   };
 });
 
 type CreateButtonLinkProps = Readonly<
-  AnchorHTMLAttributes<HTMLAnchorElement> & {
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'aria-disabled'> & {
     tooltipText?: string;
     tooltipProps?: Omit<TooltipProps, 'children' | 'title'>;
     tooltipRef?: ForwardedRef<unknown>;
@@ -45,22 +53,50 @@ export const CreateWorkspaceLink = ({
   tooltipProps = {},
   ...delegatedProps
 }: CreateButtonLinkProps) => {
-  const styles = useStyles();
   const { workspacesConfig } = useWorkspacesCardContext();
+  const canCreateWorkspace = Boolean(workspacesConfig.creationUrl);
+  const styles = useStyles({ canCreateWorkspace });
 
   return (
-    <Tooltip ref={tooltipRef} title={tooltipText} {...tooltipProps}>
+    <Tooltip
+      ref={tooltipRef}
+      title={
+        canCreateWorkspace ? tooltipText : 'Please add a template name value'
+      }
+      {...tooltipProps}
+    >
+      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles --
+          Some browsers will render out <a> elements as having no role when the
+          href value is undefined. Need to make sure that the link role is
+          always defined, no matter what. The ESLint rule is wrong here. */}
       <a
+        role="link"
         target={target}
         className={`${styles.root} ${className ?? ''}`}
+        /**
+         * Also need to make sure that the link is correctly disabled when there
+         * is no href available.
+         * @see {@link https://www.scottohara.me/blog/2021/05/28/disabled-links.html}
+         */
         href={workspacesConfig.creationUrl}
+        aria-disabled={!canCreateWorkspace}
         {...delegatedProps}
       >
         {children ?? <AddIcon />}
 
         <VisuallyHidden>
-          {tooltipText}
-          {target === '_blank' && <> (Link opens in new tab)</>}
+          {canCreateWorkspace ? (
+            <>
+              {tooltipText}
+              {target === '_blank' && <> (Link opens in new tab)</>}
+            </>
+          ) : (
+            <>
+              This component does not have a usable template name. Please see
+              the disclosure section in this widget for steps on adding this
+              information.
+            </>
+          )}
         </VisuallyHidden>
       </a>
     </Tooltip>

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.tsx
@@ -1,4 +1,8 @@
-import React, { type AnchorHTMLAttributes, type ForwardedRef } from 'react';
+import React, {
+  type AnchorHTMLAttributes,
+  type ForwardedRef,
+  type ReactElement,
+} from 'react';
 import { type Theme, makeStyles } from '@material-ui/core';
 import { useWorkspacesCardContext } from './Root';
 
@@ -10,7 +14,8 @@ type StyleInput = Readonly<{
   canCreateWorkspace: boolean;
 }>;
 
-type StyleKeys = 'root';
+type StyleKeys = 'root' | 'noLinkTooltipContainer';
+
 const useStyles = makeStyles<Theme, StyleInput, StyleKeys>(theme => {
   const padding = theme.spacing(0.5);
 
@@ -36,12 +41,17 @@ const useStyles = makeStyles<Theme, StyleInput, StyleKeys>(theme => {
           : 'inherit',
       },
     }),
+
+    noLinkTooltipContainer: {
+      display: 'block',
+      maxWidth: '24em',
+    },
   };
 });
 
 type CreateButtonLinkProps = Readonly<
   Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'aria-disabled'> & {
-    tooltipText?: string;
+    tooltipText?: string | ReactElement;
     tooltipProps?: Omit<TooltipProps, 'children' | 'title'>;
     tooltipRef?: ForwardedRef<unknown>;
   }
@@ -64,7 +74,14 @@ export const CreateWorkspaceLink = ({
     <Tooltip
       ref={tooltipRef}
       title={
-        canCreateWorkspace ? tooltipText : 'Please add a template name value'
+        canCreateWorkspace ? (
+          tooltipText
+        ) : (
+          <span className={styles.noLinkTooltipContainer}>
+            Please add a template name value. More info available in the
+            accordion at the bottom of this widget.
+          </span>
+        )
       }
       {...tooltipProps}
     >

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/EntityDataReminder.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/EntityDataReminder.tsx
@@ -13,13 +13,22 @@ type UseStyleKeys =
   | 'button'
   | 'disclosureTriangle'
   | 'disclosureBody'
-  | 'snippet';
+  | 'snippet'
+  | 'link';
 
 const useStyles = makeStyles<Theme, UseStyleProps, UseStyleKeys>(theme => ({
   root: ({ hasData }) => ({
     paddingTop: theme.spacing(1),
     borderTop: hasData ? 'none' : `1px solid ${theme.palette.divider}`,
   }),
+
+  link: {
+    color: theme.palette.link,
+
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
 
   button: {
     width: '100%',
@@ -41,12 +50,13 @@ const useStyles = makeStyles<Theme, UseStyleProps, UseStyleKeys>(theme => ({
     display: 'inline-block',
     textAlign: 'right',
     width: theme.spacing(2.25),
+    fontSize: '0.7rem',
   },
 
   disclosureBody: {
     margin: 0,
     padding: `${theme.spacing(0.5)}px ${theme.spacing(3.5)}px 0 ${theme.spacing(
-      3.75,
+      4,
     )}px`,
   },
 
@@ -89,24 +99,24 @@ export const EntityDataReminder = () => {
         <span aria-hidden className={styles.disclosureTriangle}>
           {isExpanded ? '▼' : '►'}
         </span>{' '}
-        {isExpanded ? 'Hide text' : 'Why am I seeing all workspaces?'}
+        Why am I not seeing any workspaces?
       </button>
 
       {isExpanded && (
         <p id={disclosureBodyId} className={styles.disclosureBody}>
-          This component displays all workspaces when the entity has no repo URL
-          to filter by. Consider disabling{' '}
-          <code className={styles.snippet}>readEntityData</code> (details in our{' '}
+          This component displays only displays all workspaces when the value of
+          the <code className={styles.snippet}>readEntityData</code> prop is{' '}
+          <code className={styles.snippet}>false</code>. See{' '}
           <a
             href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#notes-4"
             rel="noopener noreferrer"
             target="_blank"
-            style={{ textDecoration: 'underline', color: 'inherit' }}
+            className={styles.link}
           >
-            documentation
+            our documentation
             <VisuallyHidden> (link opens in new tab)</VisuallyHidden>
-          </a>
-          ).
+          </a>{' '}
+          for more info.
         </p>
       )}
     </div>

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ExtraActionsButton.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ExtraActionsButton.test.tsx
@@ -43,6 +43,7 @@ async function renderButton({ buttonText }: RenderInputs) {
     refetch,
   } as unknown as WorkspacesCardContext['workspacesQuery'];
   const mockContext: WorkspacesCardContext = {
+    isReadingEntityData: true,
     headerId: "Doesn't matter",
     queryFilter: "Doesn't matter",
     onFilterChange: jest.fn(),

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ExtraActionsButton.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ExtraActionsButton.test.tsx
@@ -39,22 +39,17 @@ async function renderButton({ buttonText }: RenderInputs) {
    * @todo Research how to test dependencies on useQuery
    */
   const refetch = jest.fn();
-  const mockWorkspacesQuery = {
-    refetch,
-  } as unknown as WorkspacesCardContext['workspacesQuery'];
-  const mockContext: WorkspacesCardContext = {
-    isReadingEntityData: true,
-    headerId: "Doesn't matter",
-    queryFilter: "Doesn't matter",
-    onFilterChange: jest.fn(),
+  const mockContext: Partial<WorkspacesCardContext> = {
     workspacesConfig: mockCoderWorkspacesConfig,
-    workspacesQuery: mockWorkspacesQuery,
+    workspacesQuery: {
+      refetch,
+    } as unknown as WorkspacesCardContext['workspacesQuery'],
   };
 
   const renderOutput = await renderInCoderEnvironment({
     auth,
     children: (
-      <CardContext.Provider value={mockContext}>
+      <CardContext.Provider value={mockContext as WorkspacesCardContext}>
         <ExtraActionsButton tooltipText={buttonText} />
       </CardContext.Provider>
     ),

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
@@ -181,12 +181,56 @@ describe(`${ReminderAccordion.name}`, () => {
 
     /**
      * Assuming that the user hasn't disabled showing the reminder at all, it
-     * will only appear when:
+     * will only appear when both of these are true:
      * 1. The component is set up to read entity data
      * 2. There is no repo URL that could be parsed from the entity data
      */
-    it.only('Will only display the entity data reminder when appropriate', async () => {
-      expect.hasAssertions();
+    it('Will only display the entity data reminder when appropriate', async () => {
+      type Config = Readonly<{
+        isReadingEntityData: boolean;
+        repoUrl: string | undefined;
+      }>;
+
+      const doNotDisplayConfigs: readonly Config[] = [
+        {
+          isReadingEntityData: false,
+          repoUrl: mockCoderWorkspacesConfig.repoUrl,
+        },
+        {
+          isReadingEntityData: false,
+          repoUrl: undefined,
+        },
+        {
+          isReadingEntityData: true,
+          repoUrl: mockCoderWorkspacesConfig.repoUrl,
+        },
+      ];
+
+      for (const config of doNotDisplayConfigs) {
+        const { unmount } = await renderAccordion({
+          isReadingEntityData: config.isReadingEntityData,
+          repoUrl: config.repoUrl,
+        });
+
+        const entityToggle = screen.queryByRole('button', {
+          name: matchers.toggles.entity,
+        });
+
+        expect(entityToggle).not.toBeInTheDocument();
+        unmount();
+      }
+
+      // Verify that toggle appears only this one time
+      await renderAccordion({
+        isReadingEntityData: true,
+        repoUrl: undefined,
+      });
+
+      const entityToggle = await screen.findByRole('button', {
+        name: matchers.toggles.entity,
+      });
+
+      expect(entityToggle).toBeInTheDocument();
     });
   });
 });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
@@ -1,12 +1,94 @@
-import { ReminderAccordion } from './ReminderAccordion';
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderInCoderEnvironment } from '../../testHelpers/setup';
+import {
+  type WorkspacesCardContext,
+  CardContext,
+  WorkspacesQuery,
+} from './Root';
+import {
+  type ReminderAccordionProps,
+  ReminderAccordion,
+} from './ReminderAccordion';
+import { Workspace } from '../../typesConstants';
+import { mockCoderWorkspacesConfig } from '../../testHelpers/mockBackstageData';
+
+type RenderInputs = Readonly<
+  ReminderAccordionProps & {
+    isReadingEntityData?: boolean;
+    repoUrl?: undefined | string;
+    queryData?: undefined | readonly Workspace[];
+  }
+>;
+
+function renderAccordion(inputs?: RenderInputs) {
+  const {
+    queryData = [],
+    isReadingEntityData = true,
+    showEntityReminder = true,
+    showTemplateNameReminder = true,
+    repoUrl = mockCoderWorkspacesConfig.repoUrl,
+  } = inputs ?? {};
+
+  const mockContext: WorkspacesCardContext = {
+    isReadingEntityData,
+    headerId: 'blah',
+    onFilterChange: jest.fn(),
+    queryFilter: 'blah blah blah',
+    workspacesConfig: {
+      ...mockCoderWorkspacesConfig,
+      repoUrl,
+    },
+    workspacesQuery: {
+      data: queryData,
+    } as WorkspacesQuery,
+  };
+
+  return renderInCoderEnvironment({
+    children: (
+      <CardContext.Provider value={mockContext}>
+        <ReminderAccordion
+          showEntityReminder={showEntityReminder}
+          showTemplateNameReminder={showTemplateNameReminder}
+        />
+      </CardContext.Provider>
+    ),
+  });
+}
 
 describe(`${ReminderAccordion.name}`, () => {
   it('Lets the user open a single accordion item', async () => {
-    expect.hasAssertions();
+    await renderAccordion();
+    const entityToggle = await screen.findByRole('button', {
+      name: /Why am I not seeing any workspaces\?/i,
+    });
+
+    const user = userEvent.setup();
+    await user.click(entityToggle);
+
+    const entityText = await screen.findByText(
+      /^This component only displays all workspaces when/,
+    );
+
+    expect(entityText).toBeInTheDocument();
   });
 
-  it('Will close an open accordion item when that item is clicked', async () => {
-    expect.hasAssertions();
+  it.only('Will close an open accordion item when that item is clicked', async () => {
+    await renderAccordion();
+    const entityToggle = await screen.findByRole('button', {
+      name: /Why am I not seeing any workspaces\?/i,
+    });
+
+    const user = userEvent.setup();
+    await user.click(entityToggle);
+
+    const entityText = await screen.findByText(
+      /^This component only displays all workspaces when/,
+    );
+
+    await user.click(entityToggle);
+    expect(entityText).not.toBeInTheDocument();
   });
 
   it('Will close any other open accordion items when a new item is clicked', async () => {

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
@@ -157,11 +157,21 @@ describe(`${ReminderAccordion.name}`, () => {
       }
     });
 
-    it.only('Will only display the entity data reminder when appropriate', async () => {
-      expect.hasAssertions();
+    it.only('Will NOT display the template name reminder if there is a creation URL', async () => {
+      await renderAccordion({
+        creationUrl: mockCoderWorkspacesConfig.creationUrl,
+        showTemplateNameReminder: true,
+      });
+
+      const templateToggle = screen.queryByRole('button', {
+        name: matchers.toggles.templateName,
+      });
+
+      console.log('Be sure to rename the show props to canShow!');
+      expect(templateToggle).not.toBeInTheDocument();
     });
 
-    it('Will only display the template name data reminder when appropriate', async () => {
+    it('Will only display the entity data reminder when appropriate', async () => {
       expect.hasAssertions();
     });
   });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
@@ -33,15 +33,12 @@ function renderAccordion(inputs?: RenderInputs) {
     canShowTemplateNameReminder = true,
   } = inputs ?? {};
 
-  const mockContext: WorkspacesCardContext = {
-    isReadingEntityData,
-    headerId: 'blah',
-    onFilterChange: jest.fn(),
-    queryFilter: 'blah blah blah',
+  const mockContext: Partial<WorkspacesCardContext> = {
     workspacesConfig: {
       ...mockCoderWorkspacesConfig,
       repoUrl,
       creationUrl,
+      isReadingEntityData,
     },
     workspacesQuery: {
       data: queryData,
@@ -50,7 +47,7 @@ function renderAccordion(inputs?: RenderInputs) {
 
   return renderInCoderEnvironment({
     children: (
-      <CardContext.Provider value={mockContext}>
+      <CardContext.Provider value={mockContext as WorkspacesCardContext}>
         <ReminderAccordion
           canShowEntityReminder={canShowEntityReminder}
           canShowTemplateNameReminder={canShowTemplateNameReminder}

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
@@ -75,7 +75,7 @@ const matchers = {
 describe(`${ReminderAccordion.name}`, () => {
   describe('General behavior', () => {
     it('Lets the user open a single accordion item', async () => {
-      await renderAccordion({ repoUrl: undefined });
+      await renderAccordion();
       const entityToggle = await screen.findByRole('button', {
         name: matchers.toggles.entity,
       });
@@ -88,7 +88,7 @@ describe(`${ReminderAccordion.name}`, () => {
     });
 
     it('Will close an open accordion item when that item is clicked', async () => {
-      await renderAccordion({ repoUrl: undefined });
+      await renderAccordion();
       const entityToggle = await screen.findByRole('button', {
         name: matchers.toggles.entity,
       });
@@ -102,11 +102,7 @@ describe(`${ReminderAccordion.name}`, () => {
     });
 
     it('Only lets one accordion item be open at a time', async () => {
-      await renderAccordion({
-        repoUrl: undefined,
-        creationUrl: undefined,
-      });
-
+      await renderAccordion();
       const entityToggle = await screen.findByRole('button', {
         name: matchers.toggles.entity,
       });
@@ -132,10 +128,36 @@ describe(`${ReminderAccordion.name}`, () => {
 
   describe('Conditionally displaying items', () => {
     it('Lets the user conditionally hide accordion items based on props', async () => {
-      expect.hasAssertions();
+      type Configuration = Readonly<{
+        props: ReminderAccordionProps;
+        expectedItemCount: number;
+      }>;
+
+      const configurations: readonly Configuration[] = [
+        {
+          expectedItemCount: 0,
+          props: { showEntityReminder: false, showTemplateNameReminder: false },
+        },
+        {
+          expectedItemCount: 1,
+          props: { showEntityReminder: false, showTemplateNameReminder: true },
+        },
+        {
+          expectedItemCount: 1,
+          props: { showEntityReminder: true, showTemplateNameReminder: false },
+        },
+      ];
+
+      for (const config of configurations) {
+        const { unmount } = await renderAccordion(config.props);
+        const accordionItems = screen.queryAllByRole('button');
+
+        expect(accordionItems.length).toBe(config.expectedItemCount);
+        unmount();
+      }
     });
 
-    it('Will only display the entity data reminder when appropriate', async () => {
+    it.only('Will only display the entity data reminder when appropriate', async () => {
       expect.hasAssertions();
     });
 

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
@@ -179,6 +179,12 @@ describe(`${ReminderAccordion.name}`, () => {
       expect(templateToggle).not.toBeInTheDocument();
     });
 
+    /**
+     * Assuming that the user hasn't disabled showing the reminder at all, it
+     * will only appear when:
+     * 1. The component is set up to read entity data
+     * 2. There is no repo URL that could be parsed from the entity data
+     */
     it.only('Will only display the entity data reminder when appropriate', async () => {
       expect.hasAssertions();
     });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
@@ -29,8 +29,8 @@ function renderAccordion(inputs?: RenderInputs) {
     creationUrl,
     queryData = [],
     isReadingEntityData = true,
-    showEntityReminder = true,
-    showTemplateNameReminder = true,
+    canShowEntityReminder = true,
+    canShowTemplateNameReminder = true,
   } = inputs ?? {};
 
   const mockContext: WorkspacesCardContext = {
@@ -52,8 +52,8 @@ function renderAccordion(inputs?: RenderInputs) {
     children: (
       <CardContext.Provider value={mockContext}>
         <ReminderAccordion
-          showEntityReminder={showEntityReminder}
-          showTemplateNameReminder={showTemplateNameReminder}
+          canShowEntityReminder={canShowEntityReminder}
+          canShowTemplateNameReminder={canShowTemplateNameReminder}
         />
       </CardContext.Provider>
     ),
@@ -136,15 +136,24 @@ describe(`${ReminderAccordion.name}`, () => {
       const configurations: readonly Configuration[] = [
         {
           expectedItemCount: 0,
-          props: { showEntityReminder: false, showTemplateNameReminder: false },
+          props: {
+            canShowEntityReminder: false,
+            canShowTemplateNameReminder: false,
+          },
         },
         {
           expectedItemCount: 1,
-          props: { showEntityReminder: false, showTemplateNameReminder: true },
+          props: {
+            canShowEntityReminder: false,
+            canShowTemplateNameReminder: true,
+          },
         },
         {
           expectedItemCount: 1,
-          props: { showEntityReminder: true, showTemplateNameReminder: false },
+          props: {
+            canShowEntityReminder: true,
+            canShowTemplateNameReminder: false,
+          },
         },
       ];
 
@@ -157,21 +166,20 @@ describe(`${ReminderAccordion.name}`, () => {
       }
     });
 
-    it.only('Will NOT display the template name reminder if there is a creation URL', async () => {
+    it('Will NOT display the template name reminder if there is a creation URL', async () => {
       await renderAccordion({
         creationUrl: mockCoderWorkspacesConfig.creationUrl,
-        showTemplateNameReminder: true,
+        canShowTemplateNameReminder: true,
       });
 
       const templateToggle = screen.queryByRole('button', {
         name: matchers.toggles.templateName,
       });
 
-      console.log('Be sure to rename the show props to canShow!');
       expect(templateToggle).not.toBeInTheDocument();
     });
 
-    it('Will only display the entity data reminder when appropriate', async () => {
+    it.only('Will only display the entity data reminder when appropriate', async () => {
       expect.hasAssertions();
     });
   });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
@@ -1,0 +1,19 @@
+import { ReminderAccordion } from './ReminderAccordion';
+
+describe(`${ReminderAccordion.name}`, () => {
+  it('Lets the user open a single accordion item', async () => {
+    expect.hasAssertions();
+  });
+
+  it('Will close an open accordion item when that item is clicked', async () => {
+    expect.hasAssertions();
+  });
+
+  it('Will close any other open accordion items when a new item is clicked', async () => {
+    expect.hasAssertions();
+  });
+
+  it('Lets the user conditionally hide accordion items based on props', async () => {
+    expect.hasAssertions();
+  });
+});

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.test.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
+import type { Workspace } from '../../typesConstants';
+import { mockCoderWorkspacesConfig } from '../../testHelpers/mockBackstageData';
 import {
   type WorkspacesCardContext,
+  type WorkspacesQuery,
   CardContext,
-  WorkspacesQuery,
 } from './Root';
 import {
   type ReminderAccordionProps,
   ReminderAccordion,
 } from './ReminderAccordion';
-import { Workspace } from '../../typesConstants';
-import { mockCoderWorkspacesConfig } from '../../testHelpers/mockBackstageData';
 
 type RenderInputs = Readonly<
   ReminderAccordionProps & {

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -51,8 +51,7 @@ export function ReminderAccordion({
       canDisplay:
         canShowEntityReminder &&
         isReadingEntityData &&
-        !workspacesConfig.repoUrl &&
-        workspacesQuery.data !== undefined,
+        !workspacesConfig.repoUrl,
       headerText: 'Why am I not seeing any workspaces?',
       bodyText: (
         <>

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -41,7 +41,7 @@ export function ReminderAccordion({
   showTemplateNameReminder = true,
 }: Props) {
   const [activeItemId, setActiveItemId] = useState<string>();
-  const { readEntityData, workspacesConfig, workspacesQuery } =
+  const { isReadingEntityData, workspacesConfig, workspacesQuery } =
     useWorkspacesCardContext();
   const styles = useStyles({ hasData: workspacesQuery.data !== undefined });
 
@@ -50,7 +50,7 @@ export function ReminderAccordion({
       id: 'entity',
       canDisplay:
         showEntityReminder &&
-        readEntityData &&
+        isReadingEntityData &&
         !workspacesConfig.repoUrl &&
         workspacesQuery.data !== undefined,
       headerText: 'Why am I not seeing any workspaces?',

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles<Theme, StyleInputs, StyleKeys>(theme => ({
   },
 }));
 
-type Props = Readonly<{
+export type ReminderAccordionProps = Readonly<{
   showEntityReminder?: boolean;
   showTemplateNameReminder?: boolean;
 }>;
@@ -39,7 +39,7 @@ type Props = Readonly<{
 export function ReminderAccordion({
   showEntityReminder = true,
   showTemplateNameReminder = true,
-}: Props) {
+}: ReminderAccordionProps) {
   const [activeItemId, setActiveItemId] = useState<string>();
   const { isReadingEntityData, workspacesConfig, workspacesQuery } =
     useWorkspacesCardContext();
@@ -51,13 +51,13 @@ export function ReminderAccordion({
       canDisplay:
         showEntityReminder &&
         isReadingEntityData &&
-        !workspacesConfig.repoUrl &&
+        Boolean(workspacesConfig.repoUrl) &&
         workspacesQuery.data !== undefined,
       headerText: 'Why am I not seeing any workspaces?',
       bodyText: (
         <>
-          This component displays only displays all workspaces when the value of
-          the <InlineCodeSnippet>readEntityData</InlineCodeSnippet> prop is{' '}
+          This component only displays all workspaces when the value of the{' '}
+          <InlineCodeSnippet>readEntityData</InlineCodeSnippet> prop is{' '}
           <InlineCodeSnippet>false</InlineCodeSnippet>. See{' '}
           <a
             href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#notes-4"
@@ -74,7 +74,8 @@ export function ReminderAccordion({
     },
     {
       id: 'templateName',
-      canDisplay: showTemplateNameReminder && !workspacesConfig.creationUrl,
+      canDisplay:
+        showTemplateNameReminder && Boolean(workspacesConfig.creationUrl),
       headerText: <>Why can&apos;t I make a new workspace?</>,
       bodyText: (
         <>

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -101,7 +101,7 @@ export function ReminderAccordion({
           <Snippet>templateName</Snippet> property in a repo's{' '}
           <Snippet>catalog-info.yaml</Snippet> file. See{' '}
           <a
-            href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#notes-4"
+            href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#coderappconfig"
             rel="noopener noreferrer"
             target="_blank"
             className={styles.link}

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -12,7 +12,7 @@ type AccordionItemInfo = Readonly<{
   bodyText: ReactNode;
 }>;
 
-type StyleKeys = 'root' | 'link';
+type StyleKeys = 'root' | 'link' | 'innerPadding';
 type StyleInputs = Readonly<{
   hasData: boolean;
 }>;
@@ -20,8 +20,18 @@ type StyleInputs = Readonly<{
 const useStyles = makeStyles<Theme, StyleInputs, StyleKeys>(theme => ({
   root: ({ hasData }) => ({
     paddingTop: theme.spacing(1),
+    marginLeft: `-${theme.spacing(2)}px`,
+    marginRight: `-${theme.spacing(2)}px`,
     borderTop: hasData ? 'none' : `1px solid ${theme.palette.divider}`,
+    maxHeight: '240px',
+    overflowX: 'hidden',
+    overflowY: 'auto',
   }),
+
+  innerPadding: {
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+  },
 
   link: {
     color: theme.palette.link,
@@ -98,19 +108,21 @@ export function ReminderAccordion({
 
   return (
     <div role="group" className={styles.root}>
-      {accordionData.map(({ id, canDisplay, headerText, bodyText }) => (
-        <Fragment key={id}>
-          {canDisplay && (
-            <Disclosure
-              headerText={headerText}
-              isExpanded={id === activeItemId}
-              onExpansionToggle={() => toggleAccordionGroup(id)}
-            >
-              {bodyText}
-            </Disclosure>
-          )}
-        </Fragment>
-      ))}
+      <div className={styles.innerPadding}>
+        {accordionData.map(({ id, canDisplay, headerText, bodyText }) => (
+          <Fragment key={id}>
+            {canDisplay && (
+              <Disclosure
+                headerText={headerText}
+                isExpanded={id === activeItemId}
+                onExpansionToggle={() => toggleAccordionGroup(id)}
+              >
+                {bodyText}
+              </Disclosure>
+            )}
+          </Fragment>
+        ))}
+      </div>
     </div>
   );
 }

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -1,0 +1,124 @@
+import React, { Fragment, ReactNode, useState } from 'react';
+import { useWorkspacesCardContext } from './Root';
+import { ReminderAccordionItem } from './ReminderAccordionItem';
+import { VisuallyHidden } from '../VisuallyHidden';
+import { Theme, makeStyles } from '@material-ui/core';
+
+type AccordionItemInfo = Readonly<{
+  id: string;
+  canDisplay: boolean;
+  headerText: ReactNode;
+  bodyText: ReactNode;
+}>;
+
+type UseStyleProps = Readonly<{
+  hasData: boolean;
+}>;
+
+type UseStyleKeys = 'root' | 'snippet' | 'link';
+
+const useStyles = makeStyles<Theme, UseStyleProps, UseStyleKeys>(theme => ({
+  root: ({ hasData }) => ({
+    paddingTop: theme.spacing(1),
+    borderTop: hasData ? 'none' : `1px solid ${theme.palette.divider}`,
+  }),
+
+  link: {
+    color: theme.palette.link,
+
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+
+  snippet: {
+    color: theme.palette.text.primary,
+    borderRadius: theme.spacing(0.5),
+    padding: `${theme.spacing(0.2)}px ${theme.spacing(1)}px`,
+    backgroundColor: () => {
+      const defaultBackgroundColor = theme.palette.background.default;
+      const isDefaultSpotifyLightTheme =
+        defaultBackgroundColor.toUpperCase() === '#F8F8F8';
+
+      return isDefaultSpotifyLightTheme
+        ? 'hsl(0deg,0%,93%)'
+        : defaultBackgroundColor;
+    },
+  },
+}));
+
+type Props = Readonly<{
+  showEntityReminder?: boolean;
+  showTemplateNameReminder?: boolean;
+}>;
+
+export function ReminderAccordion({
+  showEntityReminder = true,
+  showTemplateNameReminder = true,
+}: Props) {
+  const [activeItemId, setActiveItemId] = useState<string>();
+  const { readEntityData, workspacesConfig, workspacesQuery } =
+    useWorkspacesCardContext();
+  const styles = useStyles({ hasData: workspacesQuery.data !== undefined });
+
+  const toggleAccordionGroup = (newItemId: string) => {
+    if (newItemId === activeItemId) {
+      setActiveItemId(undefined);
+    } else {
+      setActiveItemId(newItemId);
+    }
+  };
+
+  const accordionData: readonly AccordionItemInfo[] = [
+    {
+      id: 'entity',
+      canDisplay:
+        showEntityReminder &&
+        readEntityData &&
+        !workspacesConfig.repoUrl &&
+        workspacesQuery.data !== undefined,
+      headerText: 'Why am I not seeing any workspaces?',
+      bodyText: (
+        <>
+          This component displays only displays all workspaces when the value of
+          the <code className={styles.snippet}>readEntityData</code> prop is{' '}
+          <code className={styles.snippet}>false</code>. See{' '}
+          <a
+            href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#notes-4"
+            rel="noopener noreferrer"
+            target="_blank"
+            className={styles.link}
+          >
+            our documentation
+            <VisuallyHidden> (link opens in new tab)</VisuallyHidden>
+          </a>{' '}
+          for more info.
+        </>
+      ),
+    },
+    {
+      id: 'templateName',
+      canDisplay: showTemplateNameReminder && !workspacesConfig.creationUrl,
+      headerText: '',
+      bodyText: 'Blah',
+    },
+  ];
+
+  return (
+    <>
+      {accordionData.map(({ id, canDisplay, headerText, bodyText }) => (
+        <Fragment key={id}>
+          {canDisplay && (
+            <ReminderAccordionItem
+              headerText={headerText}
+              isExpanded={id === activeItemId}
+              onExpansion={() => toggleAccordionGroup(id)}
+            >
+              {bodyText}
+            </ReminderAccordionItem>
+          )}
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -105,7 +105,7 @@ export function ReminderAccordion({
             <Disclosure
               headerText={headerText}
               isExpanded={id === activeItemId}
-              onExpansion={() => toggleAccordionGroup(id)}
+              onExpansionToggle={() => toggleAccordionGroup(id)}
             >
               {bodyText}
             </Disclosure>

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -41,8 +41,7 @@ export function ReminderAccordion({
   canShowTemplateNameReminder = true,
 }: ReminderAccordionProps) {
   const [activeItemId, setActiveItemId] = useState<string>();
-  const { isReadingEntityData, workspacesConfig, workspacesQuery } =
-    useWorkspacesCardContext();
+  const { workspacesConfig, workspacesQuery } = useWorkspacesCardContext();
   const styles = useStyles({ hasData: workspacesQuery.data !== undefined });
 
   const accordionData: readonly AccordionItemInfo[] = [
@@ -50,7 +49,7 @@ export function ReminderAccordion({
       id: 'entity',
       canDisplay:
         canShowEntityReminder &&
-        isReadingEntityData &&
+        workspacesConfig.isReadingEntityData &&
         !workspacesConfig.repoUrl,
       headerText: 'Why am I not seeing any workspaces?',
       bodyText: (

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -32,13 +32,13 @@ const useStyles = makeStyles<Theme, StyleInputs, StyleKeys>(theme => ({
 }));
 
 export type ReminderAccordionProps = Readonly<{
-  showEntityReminder?: boolean;
-  showTemplateNameReminder?: boolean;
+  canShowEntityReminder?: boolean;
+  canShowTemplateNameReminder?: boolean;
 }>;
 
 export function ReminderAccordion({
-  showEntityReminder = true,
-  showTemplateNameReminder = true,
+  canShowEntityReminder = true,
+  canShowTemplateNameReminder = true,
 }: ReminderAccordionProps) {
   const [activeItemId, setActiveItemId] = useState<string>();
   const { isReadingEntityData, workspacesConfig, workspacesQuery } =
@@ -49,7 +49,7 @@ export function ReminderAccordion({
     {
       id: 'entity',
       canDisplay:
-        showEntityReminder &&
+        canShowEntityReminder &&
         isReadingEntityData &&
         !workspacesConfig.repoUrl &&
         workspacesQuery.data !== undefined,
@@ -74,7 +74,7 @@ export function ReminderAccordion({
     },
     {
       id: 'templateName',
-      canDisplay: showTemplateNameReminder && !workspacesConfig.creationUrl,
+      canDisplay: canShowTemplateNameReminder && !workspacesConfig.creationUrl,
       headerText: <>Why can&apos;t I make a new workspace?</>,
       bodyText: (
         <>

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -2,7 +2,7 @@ import React, { type ReactNode, Fragment, useState } from 'react';
 import { type Theme, makeStyles } from '@material-ui/core';
 import { VisuallyHidden } from '../VisuallyHidden';
 import { useWorkspacesCardContext } from './Root';
-import { AccordionItem } from '../AccordionItem/AccordionItem';
+import { Disclosure } from '../Disclosure/Disclosure';
 import { InlineCodeSnippet } from '../InlineCodeSnippet/InlineCodeSnippet';
 
 type AccordionItemInfo = Readonly<{
@@ -99,17 +99,17 @@ export function ReminderAccordion({
   };
 
   return (
-    <div className={styles.root}>
+    <div role="group" className={styles.root}>
       {accordionData.map(({ id, canDisplay, headerText, bodyText }) => (
         <Fragment key={id}>
           {canDisplay && (
-            <AccordionItem
+            <Disclosure
               headerText={headerText}
               isExpanded={id === activeItemId}
               onExpansion={() => toggleAccordionGroup(id)}
             >
               {bodyText}
-            </AccordionItem>
+            </Disclosure>
           )}
         </Fragment>
       ))}

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -3,7 +3,7 @@ import { type Theme, makeStyles } from '@material-ui/core';
 import { VisuallyHidden } from '../VisuallyHidden';
 import { useWorkspacesCardContext } from './Root';
 import { Disclosure } from '../Disclosure/Disclosure';
-import { InlineCodeSnippet } from '../InlineCodeSnippet/InlineCodeSnippet';
+import { InlineCodeSnippet as Snippet } from '../InlineCodeSnippet/InlineCodeSnippet';
 
 type AccordionItemInfo = Readonly<{
   id: string;
@@ -73,8 +73,8 @@ export function ReminderAccordion({
       bodyText: (
         <>
           This component only displays all workspaces when the value of the{' '}
-          <InlineCodeSnippet>readEntityData</InlineCodeSnippet> prop is{' '}
-          <InlineCodeSnippet>false</InlineCodeSnippet>. See{' '}
+          <Snippet>readEntityData</Snippet> prop is <Snippet>false</Snippet>.
+          See{' '}
           <a
             href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#notes-4"
             rel="noopener noreferrer"
@@ -96,11 +96,20 @@ export function ReminderAccordion({
         <>
           This component cannot make a new workspace without a template name
           value. Values can be provided via{' '}
-          <InlineCodeSnippet>defaultTemplateName</InlineCodeSnippet> in{' '}
-          <InlineCodeSnippet>CoderAppConfig</InlineCodeSnippet> or the{' '}
-          <InlineCodeSnippet>templateName</InlineCodeSnippet> property in a
-          repo's <InlineCodeSnippet>catalog-info.yaml</InlineCodeSnippet> file.
-          See our documentation for more information.
+          <Snippet>defaultTemplateName</Snippet> in{' '}
+          <Snippet>CoderAppConfig</Snippet> or the{' '}
+          <Snippet>templateName</Snippet> property in a repo's{' '}
+          <Snippet>catalog-info.yaml</Snippet> file. See{' '}
+          <a
+            href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#notes-4"
+            rel="noopener noreferrer"
+            target="_blank"
+            className={styles.link}
+          >
+            our documentation
+            <VisuallyHidden> (link opens in new tab)</VisuallyHidden>
+          </a>{' '}
+          for more info.
         </>
       ),
     },

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -1,8 +1,9 @@
-import React, { Fragment, ReactNode, useState } from 'react';
-import { useWorkspacesCardContext } from './Root';
-import { ReminderAccordionItem } from './ReminderAccordionItem';
+import React, { type ReactNode, Fragment, useState } from 'react';
+import { type Theme, makeStyles } from '@material-ui/core';
 import { VisuallyHidden } from '../VisuallyHidden';
-import { Theme, makeStyles } from '@material-ui/core';
+import { useWorkspacesCardContext } from './Root';
+import { AccordionItem } from '../AccordionItem/AccordionItem';
+import { InlineCodeSnippet } from '../InlineCodeSnippet/InlineCodeSnippet';
 
 type AccordionItemInfo = Readonly<{
   id: string;
@@ -11,13 +12,12 @@ type AccordionItemInfo = Readonly<{
   bodyText: ReactNode;
 }>;
 
-type UseStyleProps = Readonly<{
+type StyleKeys = 'root' | 'link';
+type StyleInputs = Readonly<{
   hasData: boolean;
 }>;
 
-type UseStyleKeys = 'root' | 'snippet' | 'link';
-
-const useStyles = makeStyles<Theme, UseStyleProps, UseStyleKeys>(theme => ({
+const useStyles = makeStyles<Theme, StyleInputs, StyleKeys>(theme => ({
   root: ({ hasData }) => ({
     paddingTop: theme.spacing(1),
     borderTop: hasData ? 'none' : `1px solid ${theme.palette.divider}`,
@@ -25,24 +25,8 @@ const useStyles = makeStyles<Theme, UseStyleProps, UseStyleKeys>(theme => ({
 
   link: {
     color: theme.palette.link,
-
     '&:hover': {
       textDecoration: 'underline',
-    },
-  },
-
-  snippet: {
-    color: theme.palette.text.primary,
-    borderRadius: theme.spacing(0.5),
-    padding: `${theme.spacing(0.2)}px ${theme.spacing(1)}px`,
-    backgroundColor: () => {
-      const defaultBackgroundColor = theme.palette.background.default;
-      const isDefaultSpotifyLightTheme =
-        defaultBackgroundColor.toUpperCase() === '#F8F8F8';
-
-      return isDefaultSpotifyLightTheme
-        ? 'hsl(0deg,0%,93%)'
-        : defaultBackgroundColor;
     },
   },
 }));
@@ -61,14 +45,6 @@ export function ReminderAccordion({
     useWorkspacesCardContext();
   const styles = useStyles({ hasData: workspacesQuery.data !== undefined });
 
-  const toggleAccordionGroup = (newItemId: string) => {
-    if (newItemId === activeItemId) {
-      setActiveItemId(undefined);
-    } else {
-      setActiveItemId(newItemId);
-    }
-  };
-
   const accordionData: readonly AccordionItemInfo[] = [
     {
       id: 'entity',
@@ -81,8 +57,8 @@ export function ReminderAccordion({
       bodyText: (
         <>
           This component displays only displays all workspaces when the value of
-          the <code className={styles.snippet}>readEntityData</code> prop is{' '}
-          <code className={styles.snippet}>false</code>. See{' '}
+          the <InlineCodeSnippet>readEntityData</InlineCodeSnippet> prop is{' '}
+          <InlineCodeSnippet>false</InlineCodeSnippet>. See{' '}
           <a
             href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#notes-4"
             rel="noopener noreferrer"
@@ -99,26 +75,44 @@ export function ReminderAccordion({
     {
       id: 'templateName',
       canDisplay: showTemplateNameReminder && !workspacesConfig.creationUrl,
-      headerText: '',
-      bodyText: 'Blah',
+      headerText: <>Why can&apos;t I make a new workspace?</>,
+      bodyText: (
+        <>
+          This component cannot make a new workspace without a template name
+          value. Values can be provided via{' '}
+          <InlineCodeSnippet>defaultTemplateName</InlineCodeSnippet> in{' '}
+          <InlineCodeSnippet>CoderAppConfig</InlineCodeSnippet> or the{' '}
+          <InlineCodeSnippet>templateName</InlineCodeSnippet> property in a
+          repo's <InlineCodeSnippet>catalog-info.yaml</InlineCodeSnippet> file.
+          See our documentation for more information.
+        </>
+      ),
     },
   ];
 
+  const toggleAccordionGroup = (newItemId: string) => {
+    if (newItemId === activeItemId) {
+      setActiveItemId(undefined);
+    } else {
+      setActiveItemId(newItemId);
+    }
+  };
+
   return (
-    <>
+    <div className={styles.root}>
       {accordionData.map(({ id, canDisplay, headerText, bodyText }) => (
         <Fragment key={id}>
           {canDisplay && (
-            <ReminderAccordionItem
+            <AccordionItem
               headerText={headerText}
               isExpanded={id === activeItemId}
               onExpansion={() => toggleAccordionGroup(id)}
             >
               {bodyText}
-            </ReminderAccordionItem>
+            </AccordionItem>
           )}
         </Fragment>
       ))}
-    </>
+    </div>
   );
 }

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -51,7 +51,7 @@ export function ReminderAccordion({
       canDisplay:
         showEntityReminder &&
         isReadingEntityData &&
-        Boolean(workspacesConfig.repoUrl) &&
+        !workspacesConfig.repoUrl &&
         workspacesQuery.data !== undefined,
       headerText: 'Why am I not seeing any workspaces?',
       bodyText: (
@@ -74,8 +74,7 @@ export function ReminderAccordion({
     },
     {
       id: 'templateName',
-      canDisplay:
-        showTemplateNameReminder && Boolean(workspacesConfig.creationUrl),
+      canDisplay: showTemplateNameReminder && !workspacesConfig.creationUrl,
       headerText: <>Why can&apos;t I make a new workspace?</>,
       bodyText: (
         <>

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordion.tsx
@@ -12,7 +12,7 @@ type AccordionItemInfo = Readonly<{
   bodyText: ReactNode;
 }>;
 
-type StyleKeys = 'root' | 'link' | 'innerPadding';
+type StyleKeys = 'root' | 'link' | 'innerPadding' | 'disclosure';
 type StyleInputs = Readonly<{
   hasData: boolean;
 }>;
@@ -22,6 +22,7 @@ const useStyles = makeStyles<Theme, StyleInputs, StyleKeys>(theme => ({
     paddingTop: theme.spacing(1),
     marginLeft: `-${theme.spacing(2)}px`,
     marginRight: `-${theme.spacing(2)}px`,
+    marginBottom: `-${theme.spacing(2)}px`,
     borderTop: hasData ? 'none' : `1px solid ${theme.palette.divider}`,
     maxHeight: '240px',
     overflowX: 'hidden',
@@ -31,12 +32,19 @@ const useStyles = makeStyles<Theme, StyleInputs, StyleKeys>(theme => ({
   innerPadding: {
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
   },
 
   link: {
     color: theme.palette.link,
     '&:hover': {
       textDecoration: 'underline',
+    },
+  },
+
+  disclosure: {
+    '&:not(:first-child)': {
+      paddingTop: theme.spacing(1),
     },
   },
 }));
@@ -113,6 +121,7 @@ export function ReminderAccordion({
           <Fragment key={id}>
             {canDisplay && (
               <Disclosure
+                className={styles.disclosure}
                 headerText={headerText}
                 isExpanded={id === activeItemId}
                 onExpansionToggle={() => toggleAccordionGroup(id)}

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordionItem.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordionItem.test.tsx
@@ -3,19 +3,19 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
 import { Root } from './Root';
-import { EntityDataReminder } from './EntityDataReminder';
+import { ReminderAccordionItem } from './ReminderAccordionItem';
 
 function render() {
   return renderInCoderEnvironment({
     children: (
       <Root>
-        <EntityDataReminder />
+        <ReminderAccordionItem />
       </Root>
     ),
   });
 }
 
-describe(`${EntityDataReminder.name}`, () => {
+describe(`${ReminderAccordionItem.name}`, () => {
   it('Will toggle between showing/hiding the disclosure info when the user clicks it', async () => {
     await render();
     const user = userEvent.setup();

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordionItem.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordionItem.tsx
@@ -1,33 +1,20 @@
-import React, { useState } from 'react';
+import React, { type PropsWithChildren, type ReactNode } from 'react';
 import { useId } from '../../hooks/hookPolyfills';
-import { Theme, makeStyles } from '@material-ui/core';
-import { VisuallyHidden } from '../VisuallyHidden';
-import { useWorkspacesCardContext } from './Root';
+import { makeStyles } from '@material-ui/core';
 
-type UseStyleProps = Readonly<{
-  hasData: boolean;
-}>;
+const useStyles = makeStyles(theme => ({
+  disclosureTriangle: {
+    display: 'inline-block',
+    textAlign: 'right',
+    width: theme.spacing(2.25),
+    fontSize: '0.7rem',
+  },
 
-type UseStyleKeys =
-  | 'root'
-  | 'button'
-  | 'disclosureTriangle'
-  | 'disclosureBody'
-  | 'snippet'
-  | 'link';
-
-const useStyles = makeStyles<Theme, UseStyleProps, UseStyleKeys>(theme => ({
-  root: ({ hasData }) => ({
-    paddingTop: theme.spacing(1),
-    borderTop: hasData ? 'none' : `1px solid ${theme.palette.divider}`,
-  }),
-
-  link: {
-    color: theme.palette.link,
-
-    '&:hover': {
-      textDecoration: 'underline',
-    },
+  disclosureBody: {
+    margin: 0,
+    padding: `${theme.spacing(0.5)}px ${theme.spacing(3.5)}px 0 ${theme.spacing(
+      4,
+    )}px`,
   },
 
   button: {
@@ -45,41 +32,23 @@ const useStyles = makeStyles<Theme, UseStyleProps, UseStyleKeys>(theme => ({
       backgroundColor: theme.palette.action.hover,
     },
   },
-
-  disclosureTriangle: {
-    display: 'inline-block',
-    textAlign: 'right',
-    width: theme.spacing(2.25),
-    fontSize: '0.7rem',
-  },
-
-  disclosureBody: {
-    margin: 0,
-    padding: `${theme.spacing(0.5)}px ${theme.spacing(3.5)}px 0 ${theme.spacing(
-      4,
-    )}px`,
-  },
-
-  snippet: {
-    color: theme.palette.text.primary,
-    borderRadius: theme.spacing(0.5),
-    padding: `${theme.spacing(0.2)}px ${theme.spacing(1)}px`,
-    backgroundColor: () => {
-      const defaultBackgroundColor = theme.palette.background.default;
-      const isDefaultSpotifyLightTheme =
-        defaultBackgroundColor.toUpperCase() === '#F8F8F8';
-
-      return isDefaultSpotifyLightTheme
-        ? 'hsl(0deg,0%,93%)'
-        : defaultBackgroundColor;
-    },
-  },
 }));
 
-export const ReminderAccordionItem = () => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const { workspacesQuery } = useWorkspacesCardContext();
-  const styles = useStyles({ hasData: workspacesQuery.data !== undefined });
+type AccordionItemProps = Readonly<
+  PropsWithChildren<{
+    isExpanded: boolean;
+    onExpansion: () => void;
+    headerText: ReactNode;
+  }>
+>;
+
+export const ReminderAccordionItem = ({
+  isExpanded,
+  onExpansion,
+  headerText,
+  children,
+}: AccordionItemProps) => {
+  const styles = useStyles();
 
   const hookId = useId();
   const disclosureBodyId = `${hookId}-disclosure-body`;
@@ -88,35 +57,23 @@ export const ReminderAccordionItem = () => {
   // functionality with <detail> and <summary> elements. Would likely clean up
   // the component code a ton but might reduce control over screen reader output
   return (
-    <div className={styles.root}>
+    <div>
       <button
         type="button"
         aria-expanded={isExpanded}
         aria-controls={disclosureBodyId}
-        onClick={() => setIsExpanded(!isExpanded)}
+        onClick={onExpansion}
         className={styles.button}
       >
         <span aria-hidden className={styles.disclosureTriangle}>
           {isExpanded ? '▼' : '►'}
         </span>{' '}
-        Why am I not seeing any workspaces?
+        {headerText}
       </button>
 
       {isExpanded && (
         <p id={disclosureBodyId} className={styles.disclosureBody}>
-          This component displays only displays all workspaces when the value of
-          the <code className={styles.snippet}>readEntityData</code> prop is{' '}
-          <code className={styles.snippet}>false</code>. See{' '}
-          <a
-            href="https://github.com/coder/backstage-plugins/blob/main/plugins/backstage-plugin-coder/docs/components.md#notes-4"
-            rel="noopener noreferrer"
-            target="_blank"
-            className={styles.link}
-          >
-            our documentation
-            <VisuallyHidden> (link opens in new tab)</VisuallyHidden>
-          </a>{' '}
-          for more info.
+          {children}
         </p>
       )}
     </div>

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordionItem.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ReminderAccordionItem.tsx
@@ -76,7 +76,7 @@ const useStyles = makeStyles<Theme, UseStyleProps, UseStyleKeys>(theme => ({
   },
 }));
 
-export const EntityDataReminder = () => {
+export const ReminderAccordionItem = () => {
   const [isExpanded, setIsExpanded] = useState(false);
   const { workspacesQuery } = useWorkspacesCardContext();
   const styles = useStyles({ hasData: workspacesQuery.data !== undefined });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Root.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Root.tsx
@@ -1,9 +1,6 @@
 /**
  * @file Wires up all the core logic for passing values down to the
  * sub-components in the same directory.
- *
- * Does not need any tests – test functionality covered by integration tests in
- * CoderWorkspacesCard
  */
 import React, {
   type HTMLAttributes,
@@ -26,7 +23,6 @@ import { CoderAuthWrapper } from '../CoderAuthWrapper';
 export type WorkspacesQuery = UseQueryResult<readonly Workspace[]>;
 
 export type WorkspacesCardContext = Readonly<{
-  isReadingEntityData: boolean;
   queryFilter: string;
   onFilterChange: (newFilter: string) => void;
   workspacesQuery: WorkspacesQuery;
@@ -75,7 +71,6 @@ export const Root = ({
           headerId,
           workspacesQuery,
           workspacesConfig,
-          isReadingEntityData: readEntityData,
           queryFilter: activeFilter,
           onFilterChange: newFilter => {
             setInnerFilter(newFilter);

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Root.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Root.tsx
@@ -22,11 +22,11 @@ import type { Workspace } from '../../typesConstants';
 import { useCoderWorkspacesQuery } from '../../hooks/useCoderWorkspacesQuery';
 import { Card } from '../Card';
 import { CoderAuthWrapper } from '../CoderAuthWrapper';
-import { EntityDataReminder } from './EntityDataReminder';
 
 export type WorkspacesQuery = UseQueryResult<readonly Workspace[]>;
 
 export type WorkspacesCardContext = Readonly<{
+  readEntityData: boolean;
   queryFilter: string;
   onFilterChange: (newFilter: string) => void;
   workspacesQuery: WorkspacesQuery;
@@ -56,7 +56,6 @@ export const Root = ({
   readEntityData = false,
   ...delegatedProps
 }: WorkspacesCardProps) => {
-  const hookId = useId();
   const [innerFilter, setInnerFilter] = useState(defaultQueryFilter);
   const activeFilter = outerFilter ?? innerFilter;
 
@@ -66,17 +65,15 @@ export const Root = ({
     coderQuery: activeFilter,
   });
 
+  const hookId = useId();
   const headerId = `${hookId}-header`;
-  const showEntityDataReminder =
-    readEntityData &&
-    !workspacesConfig.repoUrl &&
-    workspacesQuery.data !== undefined;
 
   return (
     <CoderAuthWrapper type="card">
       <CardContext.Provider
         value={{
           headerId,
+          readEntityData,
           workspacesQuery,
           workspacesConfig,
           queryFilter: activeFilter,
@@ -99,7 +96,6 @@ export const Root = ({
               cases around keyboard input and button children that native <form>
               elements automatically introduce */}
           <div role="form">{children}</div>
-          {showEntityDataReminder && <EntityDataReminder />}
         </Card>
       </CardContext.Provider>
     </CoderAuthWrapper>

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Root.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Root.tsx
@@ -43,7 +43,7 @@ export type WorkspacesCardProps = Readonly<
   }
 >;
 
-export const Root = ({
+const InnerRoot = ({
   children,
   className,
   queryFilter: outerFilter,
@@ -96,6 +96,16 @@ export const Root = ({
     </CoderAuthWrapper>
   );
 };
+
+export function Root(props: WorkspacesCardProps) {
+  // Doing this to insulate the user from needing to worry about accidentally
+  // flipping the value of readEntityData between renders. If this value
+  // changes, it will cause the component to unmount and remount, but that
+  // should be painless/maybe invisible compared to having the component throw
+  // a full error and triggering an error boundary
+  const renderKey = String(props.readEntityData ?? false);
+  return <InnerRoot key={renderKey} {...props} />;
+}
 
 export function useWorkspacesCardContext(): WorkspacesCardContext {
   const contextValue = useContext(CardContext);

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Root.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Root.tsx
@@ -26,7 +26,7 @@ import { CoderAuthWrapper } from '../CoderAuthWrapper';
 export type WorkspacesQuery = UseQueryResult<readonly Workspace[]>;
 
 export type WorkspacesCardContext = Readonly<{
-  readEntityData: boolean;
+  isReadingEntityData: boolean;
   queryFilter: string;
   onFilterChange: (newFilter: string) => void;
   workspacesQuery: WorkspacesQuery;
@@ -73,9 +73,9 @@ export const Root = ({
       <CardContext.Provider
         value={{
           headerId,
-          readEntityData,
           workspacesQuery,
           workspacesConfig,
+          isReadingEntityData: readEntityData,
           queryFilter: activeFilter,
           onFilterChange: newFilter => {
             setInnerFilter(newFilter);

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/SearchBox.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/SearchBox.test.tsx
@@ -31,6 +31,7 @@ async function renderSearchBox(input?: RenderInputs) {
   const mockContext: WorkspacesCardContext = {
     onFilterChange,
     queryFilter,
+    isReadingEntityData: true,
     headerId: "Doesn't matter",
     workspacesConfig: mockCoderWorkspacesConfig,
     workspacesQuery:

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/SearchBox.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/SearchBox.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
 import { CardContext, WorkspacesCardContext } from './Root';
 import { SearchBox } from './SearchBox';
-import { mockCoderWorkspacesConfig } from '../../testHelpers/mockBackstageData';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -28,19 +27,14 @@ async function renderSearchBox(input?: RenderInputs) {
   const { queryFilter = 'owner:me' } = input ?? {};
   const onFilterChange = jest.fn();
 
-  const mockContext: WorkspacesCardContext = {
+  const mockContext: Partial<WorkspacesCardContext> = {
     onFilterChange,
     queryFilter,
-    isReadingEntityData: true,
-    headerId: "Doesn't matter",
-    workspacesConfig: mockCoderWorkspacesConfig,
-    workspacesQuery:
-      null as unknown as WorkspacesCardContext['workspacesQuery'],
   };
 
   const renderOutput = await renderInCoderEnvironment({
     children: (
-      <CardContext.Provider value={mockContext}>
+      <CardContext.Provider value={mockContext as WorkspacesCardContext}>
         <SearchBox />
       </CardContext.Provider>
     ),

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesList.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesList.test.tsx
@@ -15,12 +15,7 @@ type RenderInputs = Readonly<{
 
 function renderWorkspacesList(inputs?: RenderInputs) {
   const { renderListItem, workspacesQuery, repoUrl } = inputs ?? {};
-
-  const mockContext: WorkspacesCardContext = {
-    isReadingEntityData: true,
-    headerId: "Doesn't matter",
-    queryFilter: "Also doesn't matter",
-    onFilterChange: jest.fn(),
+  const mockContext: Partial<WorkspacesCardContext> = {
     workspacesQuery: workspacesQuery as WorkspacesQuery,
     workspacesConfig: {
       ...mockCoderWorkspacesConfig,
@@ -30,7 +25,7 @@ function renderWorkspacesList(inputs?: RenderInputs) {
 
   return renderInCoderEnvironment({
     children: (
-      <CardContext.Provider value={mockContext}>
+      <CardContext.Provider value={mockContext as WorkspacesCardContext}>
         <WorkspacesList renderListItem={renderListItem} />
       </CardContext.Provider>
     ),

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesList.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesList.test.tsx
@@ -16,6 +16,7 @@ function renderWorkspacesList(inputs?: RenderInputs) {
   const { renderListItem, workspacesQuery } = inputs ?? {};
 
   const mockContext: WorkspacesCardContext = {
+    isReadingEntityData: true,
     headerId: "Doesn't matter",
     queryFilter: "Also doesn't matter",
     onFilterChange: jest.fn(),
@@ -62,5 +63,9 @@ describe(`${WorkspacesList.name}`, () => {
 
       expect(listItem).toBeInstanceOf(HTMLLIElement);
     }
+  });
+
+  it('Does not display the call-to-action button for making new workspaces when there is no workspace creation URL', async () => {
+    expect.hasAssertions();
   });
 });

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesList.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesList.tsx
@@ -97,7 +97,7 @@ export const WorkspacesList = ({
       {workspacesQuery.data?.length === 0 && (
         <>
           {emptyState ?? (
-            <Placeholder displayCta>
+            <Placeholder displayCta={Boolean(repoUrl)}>
               {repoUrl ? (
                 <div style={{ textAlign: 'center' }}>
                   No workspaces found for repo

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesList.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesList.tsx
@@ -99,10 +99,10 @@ export const WorkspacesList = ({
           {emptyState ?? (
             <Placeholder displayCta={Boolean(repoUrl)}>
               {repoUrl ? (
-                <div style={{ textAlign: 'center' }}>
+                <span style={{ display: 'block', textAlign: 'center' }}>
                   No workspaces found for repo
                   <code className={styles.code}>{repoUrl}</code>
-                </div>
+                </span>
               ) : (
                 <>No workspaces returned for your query</>
               )}

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/index.ts
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/index.ts
@@ -7,3 +7,4 @@ export * from './SearchBox';
 export * from './WorkspacesList';
 export * from './WorkspacesListIcon';
 export * from './WorkspacesListItem';
+export * from './ReminderAccordion';

--- a/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.test.tsx
@@ -3,19 +3,24 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
 import { Root } from '../CoderWorkspacesCard/Root';
-import { AccordionItem } from './AccordionItem';
+import { Disclosure } from './Disclosure';
+
+type RenderInputs = Readonly<{
+  headerText: string;
+  children: string;
+}>;
 
 function render() {
   return renderInCoderEnvironment({
     children: (
       <Root>
-        <AccordionItem />
+        <Disclosure />
       </Root>
     ),
   });
 }
 
-describe(`${AccordionItem.name}`, () => {
+describe(`${Disclosure.name}`, () => {
   it('Will toggle between showing/hiding the disclosure info when the user clicks it', async () => {
     await render();
     const user = userEvent.setup();

--- a/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.test.tsx
@@ -2,38 +2,70 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderInCoderEnvironment } from '../../testHelpers/setup';
-import { Root } from '../CoderWorkspacesCard/Root';
-import { Disclosure } from './Disclosure';
+import { type DisclosureProps, Disclosure } from './Disclosure';
 
-type RenderInputs = Readonly<{
-  headerText: string;
-  children: string;
-}>;
+type RenderInputs = Partial<DisclosureProps>;
 
-function render() {
+function render(inputs?: RenderInputs) {
+  const { headerText, children, isExpanded, onExpansion } = inputs ?? {};
+
   return renderInCoderEnvironment({
     children: (
-      <Root>
-        <Disclosure />
-      </Root>
+      <Disclosure
+        headerText={headerText}
+        isExpanded={isExpanded}
+        onExpansion={onExpansion}
+      >
+        {children}
+      </Disclosure>
     ),
   });
 }
 
 describe(`${Disclosure.name}`, () => {
   it('Will toggle between showing/hiding the disclosure info when the user clicks it', async () => {
-    await render();
+    const headerText = 'Blah';
+    const children = 'Blah blah blah blah';
+    await render({ headerText, children });
+
     const user = userEvent.setup();
-    const disclosureButton = screen.getByRole('button', {
-      name: /Why am I seeing all workspaces\?/,
+    const disclosureButton = screen.getByRole('button', { name: headerText });
+    await user.click(disclosureButton);
+
+    const disclosureInfo = await screen.findByText(children);
+    await user.click(disclosureButton);
+    expect(disclosureInfo).not.toBeInTheDocument();
+  });
+
+  it('Can flip from an uncontrolled input to a controlled one if additional props are passed in', async () => {
+    const headerText = 'Blah';
+    const children = 'Blah blah blah blah';
+    const onExpansion = jest.fn();
+
+    const { rerender } = await render({
+      onExpansion,
+      headerText,
+      children,
+      isExpanded: true,
     });
 
-    await user.click(disclosureButton);
-    const disclosureInfo = await screen.findByText(
-      /This component displays all workspaces when the entity has no repo URL to filter by/,
-    );
+    const user = userEvent.setup();
+    const disclosureInfo = await screen.findByText(children);
+    const disclosureButton = screen.getByRole('button', { name: headerText });
 
     await user.click(disclosureButton);
+    expect(onExpansion).toHaveBeenCalled();
+
+    rerender(
+      <Disclosure
+        headerText={headerText}
+        onExpansion={onExpansion}
+        isExpanded={false}
+      >
+        {children}
+      </Disclosure>,
+    );
+
     expect(disclosureInfo).not.toBeInTheDocument();
   });
 });

--- a/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.test.tsx
+++ b/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.test.tsx
@@ -1,32 +1,29 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderInCoderEnvironment } from '../../testHelpers/setup';
 import { type DisclosureProps, Disclosure } from './Disclosure';
 
 type RenderInputs = Partial<DisclosureProps>;
 
-function render(inputs?: RenderInputs) {
-  const { headerText, children, isExpanded, onExpansion } = inputs ?? {};
+function renderDisclosure(inputs?: RenderInputs) {
+  const { headerText, children, isExpanded, onExpansionToggle } = inputs ?? {};
 
-  return renderInCoderEnvironment({
-    children: (
-      <Disclosure
-        headerText={headerText}
-        isExpanded={isExpanded}
-        onExpansion={onExpansion}
-      >
-        {children}
-      </Disclosure>
-    ),
-  });
+  return render(
+    <Disclosure
+      headerText={headerText}
+      isExpanded={isExpanded}
+      onExpansionToggle={onExpansionToggle}
+    >
+      {children}
+    </Disclosure>,
+  );
 }
 
 describe(`${Disclosure.name}`, () => {
   it('Will toggle between showing/hiding the disclosure info when the user clicks it', async () => {
     const headerText = 'Blah';
     const children = 'Blah blah blah blah';
-    await render({ headerText, children });
+    renderDisclosure({ headerText, children });
 
     const user = userEvent.setup();
     const disclosureButton = screen.getByRole('button', { name: headerText });
@@ -40,10 +37,10 @@ describe(`${Disclosure.name}`, () => {
   it('Can flip from an uncontrolled input to a controlled one if additional props are passed in', async () => {
     const headerText = 'Blah';
     const children = 'Blah blah blah blah';
-    const onExpansion = jest.fn();
+    const onExpansionToggle = jest.fn();
 
-    const { rerender } = await render({
-      onExpansion,
+    const { rerender } = renderDisclosure({
+      onExpansionToggle,
       headerText,
       children,
       isExpanded: true,
@@ -54,12 +51,12 @@ describe(`${Disclosure.name}`, () => {
     const disclosureButton = screen.getByRole('button', { name: headerText });
 
     await user.click(disclosureButton);
-    expect(onExpansion).toHaveBeenCalled();
+    expect(onExpansionToggle).toHaveBeenCalled();
 
     rerender(
       <Disclosure
         headerText={headerText}
-        onExpansion={onExpansion}
+        onExpansionToggle={onExpansionToggle}
         isExpanded={false}
       >
         {children}

--- a/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.tsx
+++ b/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.tsx
@@ -1,4 +1,4 @@
-import React, { useState, type PropsWithChildren, type ReactNode } from 'react';
+import React, { type HTMLAttributes, type ReactNode, useState } from 'react';
 import { useId } from '../../hooks/hookPolyfills';
 import { makeStyles } from '@material-ui/core';
 
@@ -31,15 +31,19 @@ const useStyles = makeStyles(theme => ({
     '&:hover': {
       backgroundColor: theme.palette.action.hover,
     },
+
+    '&:not(:first-child)': {
+      paddingTop: theme.spacing(6),
+    },
   },
 }));
 
 export type DisclosureProps = Readonly<
-  PropsWithChildren<{
+  HTMLAttributes<HTMLDivElement> & {
     isExpanded?: boolean;
     onExpansionToggle?: () => void;
     headerText: ReactNode;
-  }>
+  }
 >;
 
 export const Disclosure = ({
@@ -47,6 +51,7 @@ export const Disclosure = ({
   onExpansionToggle,
   headerText,
   children,
+  ...delegatedProps
 }: DisclosureProps) => {
   const hookId = useId();
   const styles = useStyles();
@@ -61,7 +66,7 @@ export const Disclosure = ({
   // functionality with <detail> and <summary> elements. Would likely clean up
   // the component code a bit but might reduce control over screen reader output
   return (
-    <div>
+    <div {...delegatedProps}>
       <button
         type="button"
         aria-expanded={activeIsExpanded}

--- a/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.tsx
+++ b/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren, type ReactNode } from 'react';
+import React, { useState, type PropsWithChildren, type ReactNode } from 'react';
 import { useId } from '../../hooks/hookPolyfills';
 import { makeStyles } from '@material-ui/core';
 
@@ -34,10 +34,10 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-type Props = Readonly<
+export type DisclosureProps = Readonly<
   PropsWithChildren<{
-    isExpanded: boolean;
-    onExpansion: () => void;
+    isExpanded?: boolean;
+    onExpansion?: () => void;
     headerText: ReactNode;
   }>
 >;
@@ -47,9 +47,14 @@ export const Disclosure = ({
   onExpansion,
   headerText,
   children,
-}: Props) => {
-  const styles = useStyles();
+}: DisclosureProps) => {
   const hookId = useId();
+  const styles = useStyles();
+  const [internalIsExpanded, setInternalIsExpanded] = useState(
+    isExpanded ?? false,
+  );
+
+  const activeIsExpanded = isExpanded ?? internalIsExpanded;
   const disclosureBodyId = `${hookId}-disclosure-body`;
 
   // Might be worth revisiting the markup here to try implementing this
@@ -59,18 +64,21 @@ export const Disclosure = ({
     <div>
       <button
         type="button"
-        aria-expanded={isExpanded}
+        aria-expanded={activeIsExpanded}
         aria-controls={disclosureBodyId}
-        onClick={onExpansion}
         className={styles.button}
+        onClick={() => {
+          setInternalIsExpanded(!internalIsExpanded);
+          onExpansion?.();
+        }}
       >
         <span aria-hidden className={styles.disclosureTriangle}>
-          {isExpanded ? '▼' : '►'}
+          {activeIsExpanded ? '▼' : '►'}
         </span>{' '}
         {headerText}
       </button>
 
-      {isExpanded && (
+      {activeIsExpanded && (
         <p id={disclosureBodyId} className={styles.disclosureBody}>
           {children}
         </p>

--- a/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.tsx
+++ b/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.tsx
@@ -37,14 +37,14 @@ const useStyles = makeStyles(theme => ({
 export type DisclosureProps = Readonly<
   PropsWithChildren<{
     isExpanded?: boolean;
-    onExpansion?: () => void;
+    onExpansionToggle?: () => void;
     headerText: ReactNode;
   }>
 >;
 
 export const Disclosure = ({
   isExpanded,
-  onExpansion,
+  onExpansionToggle,
   headerText,
   children,
 }: DisclosureProps) => {
@@ -69,7 +69,7 @@ export const Disclosure = ({
         className={styles.button}
         onClick={() => {
           setInternalIsExpanded(!internalIsExpanded);
-          onExpansion?.();
+          onExpansionToggle?.();
         }}
       >
         <span aria-hidden className={styles.disclosureTriangle}>

--- a/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.tsx
+++ b/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-type AccordionItemProps = Readonly<
+type Props = Readonly<
   PropsWithChildren<{
     isExpanded: boolean;
     onExpansion: () => void;
@@ -42,19 +42,19 @@ type AccordionItemProps = Readonly<
   }>
 >;
 
-export const AccordionItem = ({
+export const Disclosure = ({
   isExpanded,
   onExpansion,
   headerText,
   children,
-}: AccordionItemProps) => {
+}: Props) => {
   const styles = useStyles();
   const hookId = useId();
   const disclosureBodyId = `${hookId}-disclosure-body`;
 
   // Might be worth revisiting the markup here to try implementing this
   // functionality with <detail> and <summary> elements. Would likely clean up
-  // the component code a ton but might reduce control over screen reader output
+  // the component code a bit but might reduce control over screen reader output
   return (
     <div>
       <button

--- a/plugins/backstage-plugin-coder/src/components/InlineCodeSnippet/InlineCodeSnippet.tsx
+++ b/plugins/backstage-plugin-coder/src/components/InlineCodeSnippet/InlineCodeSnippet.tsx
@@ -1,0 +1,32 @@
+import React, { HTMLAttributes } from 'react';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.text.primary,
+    borderRadius: theme.spacing(0.5),
+    padding: `${theme.spacing(0.2)}px ${theme.spacing(1)}px`,
+    backgroundColor: () => {
+      const isLightTheme = theme.palette.type === 'light';
+      return isLightTheme
+        ? 'hsl(0deg,0%,93%)'
+        : theme.palette.background.default;
+    },
+  },
+}));
+
+type Props = Readonly<
+  Omit<HTMLAttributes<HTMLElement>, 'children'> & {
+    children: string;
+  }
+>;
+
+export function InlineCodeSnippet({ children, ...delegatedProps }: Props) {
+  const styles = useStyles();
+  return (
+    <code className={styles.root} {...delegatedProps}>
+      {children}
+    </code>
+  );
+}

--- a/plugins/backstage-plugin-coder/src/hooks/useCoderWorkspacesConfig.test.ts
+++ b/plugins/backstage-plugin-coder/src/hooks/useCoderWorkspacesConfig.test.ts
@@ -111,6 +111,7 @@ describe(`${useCoderWorkspacesConfig.name}`, () => {
     );
 
     expect(result.current).toEqual<CoderWorkspacesConfig>({
+      isReadingEntityData: true,
       mode: mockYamlConfig.mode,
       repoUrl: cleanedRepoUrl,
       creationUrl: mockCoderWorkspacesConfig.creationUrl,

--- a/plugins/backstage-plugin-coder/src/hooks/useCoderWorkspacesConfig.ts
+++ b/plugins/backstage-plugin-coder/src/hooks/useCoderWorkspacesConfig.ts
@@ -23,19 +23,22 @@ import {
   useCoderAppConfig,
 } from '../components/CoderProvider';
 
+const workspaceCreationModeSchema = optional(
+  union(
+    [literal('manual'), literal('auto')],
+    "If defined, createMode must be 'manual' or 'auto'",
+  ),
+);
+
+export type WorkspaceCreationMode = Output<typeof workspaceCreationModeSchema>;
+
 // Very loose parsing requirements to make interfacing with various kinds of
 // YAML files as easy as possible
 const yamlConfigSchema = union([
   undefined_(),
   object({
     templateName: optional(string()),
-    mode: optional(
-      union(
-        [literal('manual'), literal('auto')],
-        "If defined, createMode must be 'manual' or 'auto'",
-      ),
-    ),
-
+    mode: workspaceCreationModeSchema,
     params: optional(
       record(
         string(),
@@ -49,6 +52,11 @@ const yamlConfigSchema = union([
   }),
 ]);
 
+/**
+ * The set of properties that the Coder plugin is configured to parse from a
+ * repo's catalog-info.yaml file. The entire value will be undefined if a repo
+ * does not have the file
+ */
 export type YamlConfig = Output<typeof yamlConfigSchema>;
 
 /**
@@ -56,11 +64,11 @@ export type YamlConfig = Output<typeof yamlConfigSchema>;
  * sourced from CoderAppConfig and any entity data.
  */
 export type CoderWorkspacesConfig =
-  // Was originally defined in terms of fancy mapped types; ended up being a bad
-  // idea, because it increased coupling in a bad way
+  // Was originally defined in terms of fancy mapped types based on YamlConfig;
+  // ended up being a bad idea, because it increased coupling in a bad way
   Readonly<{
-    creationUrl: string;
-    templateName: string;
+    creationUrl?: string;
+    templateName?: string;
     repoUrlParamKeys: readonly string[];
     mode: 'manual' | 'auto';
     params: Record<string, string | undefined>;
@@ -76,7 +84,9 @@ export function compileCoderConfig(
 ): CoderWorkspacesConfig {
   const { workspaces, deployment } = appConfig;
   const yamlConfig = parse(yamlConfigSchema, rawYamlConfig);
-  const mode = yamlConfig?.mode ?? workspaces.mode ?? 'manual';
+  const mode = yamlConfig?.mode ?? workspaces.defaultMode ?? 'manual';
+  const templateName =
+    yamlConfig?.templateName ?? workspaces.defaultTemplateName;
 
   const urlParams = new URLSearchParams({ mode });
   const compiledParams: Record<string, string | undefined> = {};
@@ -112,21 +122,22 @@ export function compileCoderConfig(
     }
   }
 
-  const safeTemplate = encodeURIComponent(
-    yamlConfig?.templateName ?? workspaces.templateName,
-  );
+  let creationUrl: string | undefined = undefined;
+  if (templateName) {
+    const safeTemplate = encodeURIComponent(templateName);
 
-  const creationUrl = `${
-    deployment.accessUrl
-  }/templates/${safeTemplate}/workspace?${urlParams.toString()}`;
+    creationUrl = `${
+      deployment.accessUrl
+    }/templates/${safeTemplate}/workspace?${urlParams.toString()}`;
+  }
 
   return {
+    mode,
     creationUrl,
+    templateName,
     repoUrl: cleanedRepoUrl,
     repoUrlParamKeys: workspaces.repoUrlParamKeys,
     params: compiledParams,
-    templateName: yamlConfig?.templateName ?? workspaces.templateName,
-    mode: yamlConfig?.mode ?? workspaces.mode ?? 'manual',
   };
 }
 

--- a/plugins/backstage-plugin-coder/src/hooks/useCoderWorkspacesConfig.ts
+++ b/plugins/backstage-plugin-coder/src/hooks/useCoderWorkspacesConfig.ts
@@ -67,6 +67,7 @@ export type CoderWorkspacesConfig =
   // Was originally defined in terms of fancy mapped types based on YamlConfig;
   // ended up being a bad idea, because it increased coupling in a bad way
   Readonly<{
+    isReadingEntityData: boolean;
     creationUrl?: string;
     templateName?: string;
     repoUrlParamKeys: readonly string[];
@@ -135,6 +136,7 @@ export function compileCoderConfig(
     creationUrl,
     templateName,
     repoUrl: cleanedRepoUrl,
+    isReadingEntityData: yamlConfig !== undefined,
     repoUrlParamKeys: workspaces.repoUrlParamKeys,
     params: compiledParams,
   };

--- a/plugins/backstage-plugin-coder/src/hooks/useCoderWorkspacesConfig.ts
+++ b/plugins/backstage-plugin-coder/src/hooks/useCoderWorkspacesConfig.ts
@@ -79,7 +79,7 @@ export type CoderWorkspacesConfig =
 
 export function compileCoderConfig(
   appConfig: CoderAppConfig,
-  rawYamlConfig: unknown,
+  rawYamlConfig: unknown, // Function parses this into more specific type
   repoUrl: string | undefined,
 ): CoderWorkspacesConfig {
   const { workspaces, deployment } = appConfig;
@@ -91,7 +91,7 @@ export function compileCoderConfig(
   const urlParams = new URLSearchParams({ mode });
   const compiledParams: Record<string, string | undefined> = {};
 
-  // Can't replace this with destructuring, because that is all-or-nothing;
+  // Can't replace section with destructuring, because that's all-or-nothing;
   // there's no easy way to granularly check each property without a loop
   const paramsPrecedence = [workspaces.params, yamlConfig?.params ?? {}];
   for (const params of paramsPrecedence) {
@@ -125,7 +125,6 @@ export function compileCoderConfig(
   let creationUrl: string | undefined = undefined;
   if (templateName) {
     const safeTemplate = encodeURIComponent(templateName);
-
     creationUrl = `${
       deployment.accessUrl
     }/templates/${safeTemplate}/workspace?${urlParams.toString()}`;

--- a/plugins/backstage-plugin-coder/src/plugin.ts
+++ b/plugins/backstage-plugin-coder/src/plugin.ts
@@ -149,6 +149,18 @@ export const CoderWorkspacesCardWorkspacesListItem = coderPlugin.provide(
   }),
 );
 
+export const CoderWorkspacesReminderAccordion = coderPlugin.provide(
+  createComponentExtension({
+    name: 'CoderWorkspacesCard.ReminderAccordion',
+    component: {
+      lazy: () =>
+        import('./components/CoderWorkspacesCard').then(
+          m => m.ReminderAccordion,
+        ),
+    },
+  }),
+);
+
 /**
  * All custom hooks exposed by the plugin.
  */

--- a/plugins/backstage-plugin-coder/src/testHelpers/mockBackstageData.ts
+++ b/plugins/backstage-plugin-coder/src/testHelpers/mockBackstageData.ts
@@ -110,6 +110,7 @@ export const mockCoderWorkspacesConfig = (() => {
 
   return {
     mode: 'auto',
+    isReadingEntityData: true,
     templateName: mockYamlConfig.templateName,
     repoUrlParamKeys: ['custom_repo', 'repo_url'],
     repoUrl: cleanedRepoUrl,

--- a/plugins/backstage-plugin-coder/src/testHelpers/mockBackstageData.ts
+++ b/plugins/backstage-plugin-coder/src/testHelpers/mockBackstageData.ts
@@ -89,8 +89,8 @@ export const mockAppConfig = {
   },
 
   workspaces: {
-    templateName: 'devcontainers',
-    mode: 'manual',
+    defaultTemplateName: 'devcontainers',
+    defaultMode: 'manual',
     repoUrlParamKeys: ['custom_repo', 'repo_url'],
     params: {
       repo: 'custom',

--- a/plugins/backstage-plugin-coder/src/testHelpers/mockBackstageData.ts
+++ b/plugins/backstage-plugin-coder/src/testHelpers/mockBackstageData.ts
@@ -99,7 +99,7 @@ export const mockAppConfig = {
   },
 } as const satisfies CoderAppConfig;
 
-export const mockCoderWorkspacesConfig: CoderWorkspacesConfig = (() => {
+export const mockCoderWorkspacesConfig = (() => {
   const urlParams = new URLSearchParams({
     mode: mockYamlConfig.mode,
     'param.repo': mockAppConfig.workspaces.params.repo,
@@ -124,7 +124,7 @@ export const mockCoderWorkspacesConfig: CoderWorkspacesConfig = (() => {
       custom_repo: cleanedRepoUrl,
       repo_url: cleanedRepoUrl,
     },
-  };
+  } as const satisfies CoderWorkspacesConfig;
 })();
 
 const authedState = {


### PR DESCRIPTION
Closes #59 

## Changes made
- Updated `CoderWorkspacesConfig` by adding an `isReadingEntityData` value
- Added two new general-purpose components
   - `InlineCodeSnippet`
   - `Disclosure`
- Turned `EntityDataReminder` into `ReminderAccordion` (uses `Disclosure` as its main building block)
   - This will let us keep adding more reminder information over time as different accordion entries
   - Thought there were too many edge cases around trying to reflect the lack of a template name in the main workspaces list itself, so I pulled it out, and combined it with our existing reminder for entities
   - Similarly, I felt like adding support for 100% bespoke messages for reminders like this was too much complexity for a niche feature that might not get used. Admins can choose which reminders they want to always be turned off
   - This is also now part of the exported components for the plugin
- The main piece: made template names optional, and accounted for everything that entails
   - `CoderAppConfig` now exposes `defaultTemplateName` and `defaultMode` (both optional)
   - `CoderWorkspacesConfig`'s `creationUrl` property is now potentially undefined
   - Updated the workspace creation links to be disabled when there is no URL
   - Updated UI to hide the call-to-action button for making workspaces when there is no usable URL
   - Added a new accordion entry that displays when there is no usable workspace creation URL
- Added/updated test cases where relevant

## Notes
- Just because this PR is so chunky, I'm going to split the doc updates off into a separate PR