### PR TITLE
docs: update documentation to better reflect current releases

### DIFF
--- a/plugins/backstage-plugin-coder/docs/README.md
+++ b/plugins/backstage-plugin-coder/docs/README.md
@@ -2,6 +2,8 @@
 
 For users who need more information about how to extend and modify the Coder plugin. For general setup, please see our main [README](../README.md).
 
+All documentation reflects version `v0.2.0` of the plugin. Note that breaking API changes may continue to happen for minor versions until the plugin reaches version `v1.0.0`.
+
 ## Documentation directory
 
 - [Components](./components.md)

--- a/plugins/backstage-plugin-devcontainers-backend/README.md
+++ b/plugins/backstage-plugin-devcontainers-backend/README.md
@@ -76,7 +76,6 @@ _Note: While this plugin has been developed and published by Coder, no Coder ins
        DevcontainersProcessor.fromConfig(env.config, {
          tagName: 'example', // Defaults to devcontainers
          logger: env.logger,
-         eraseTags: false,
        }),
      );
 
@@ -115,7 +114,6 @@ export default async function createPlugin(
   builder.addProcessor(
     DevcontainersProcessor.fromConfig(env.config, {
       logger: env.logger,
-      eraseTags: false,
     }),
   );
 

--- a/plugins/backstage-plugin-devcontainers-backend/docs/README.md
+++ b/plugins/backstage-plugin-devcontainers-backend/docs/README.md
@@ -2,6 +2,8 @@
 
 For users who need more information about how to extend and modify the Dev Containers plugin. For general setup, please see our main [README](../README.md).
 
+All documentation reflects version `v0.1.0` of the plugin. Note that breaking API changes may continue to happen for minor versions until the plugin reaches version `v1.0.0`.
+
 ## Documentation directory
 
 - [Classes](./classes.md)

--- a/plugins/backstage-plugin-devcontainers-backend/docs/classes.md
+++ b/plugins/backstage-plugin-devcontainers-backend/docs/classes.md
@@ -15,7 +15,6 @@ This class provides a custom [catalog processor](https://backstage.io/docs/featu
 ```tsx
 type ProcessorOptions = Readonly<{
   tagName: string;
-  eraseTags: boolean;
   logger: Logger;
 }>;
 
@@ -62,7 +61,6 @@ export default async function createPlugin(
   builder.addProcessor(
     DevcontainersProcessor.fromConfig(env.config, {
       logger: env.logger,
-      eraseTags: false,
     }),
   );
 

--- a/plugins/backstage-plugin-devcontainers-react/docs/README.md
+++ b/plugins/backstage-plugin-devcontainers-react/docs/README.md
@@ -2,6 +2,8 @@
 
 For users who need more information about how to extend and modify the Dev Containers plugin. For general setup, please see our main [README](../README.md).
 
+All documentation reflects version `v0.1.0` of the plugin. Note that breaking API changes may continue to happen for minor versions until the plugin reaches version `v1.0.0`.
+
 ## Documentation directory
 
 - [Components](./components.md)


### PR DESCRIPTION
Connected to #63

## Changes made
- Updates the `backstage-plugin-devcontainers-backend` READMEs to remove all APIs that no longer exist
- Adds disclaimers to each plugin's directory README to indicate what version the documentation is based on

## Notes
- I do think that we'll need to figure out versioned docs once we're stable enough to hit `v1.0.0`, but because we're so early, it felt better to add a disclaimer that things are subject to change a lot as we figure things out
   - I've also been much more deliberate about highlighting breaking changes for each new release