### PR TITLE
docs: fix broken link

### DIFF
--- a/plugins/backstage-plugin-coder/README.md
+++ b/plugins/backstage-plugin-coder/README.md
@@ -142,7 +142,7 @@ spec:
       region: 'us-pittsburgh'
 ```
 
-You can find more information about what properties are available (and how they're applied) in our [`catalog-info.yaml` file documentation](./docs/catalog-info.md).
+You can find more information about what properties are available (and how they're applied) in our [`catalog-info.yaml` file documentation](./docs/api-reference/catalog-info.md).
 
 ## Roadmap
 


### PR DESCRIPTION
Fix the broken link in backstage-plugin-coder description.

The new location of the link can be confirmed from the following PR:
https://github.com/coder/backstage-plugins/pull/133