### PR TITLE
docs: fix incorrect description in backstage-plugin-coder

### DIFF
--- a/plugins/backstage-plugin-coder/README.md
+++ b/plugins/backstage-plugin-coder/README.md
@@ -117,7 +117,7 @@ the Dev Container.
    );
    ```
 
-### `app-config.yaml` files
+### `catalog-info.yaml` files
 
 In addition to the above, you can define additional properties on your specific repo's `catalog-info.yaml` file.
 

--- a/plugins/backstage-plugin-coder/docs/api-reference/catalog-info.md
+++ b/plugins/backstage-plugin-coder/docs/api-reference/catalog-info.md
@@ -42,7 +42,7 @@ This defines the name of the Coder template you would like to use when creating 
 
 **Note:** This value has overlap with the `defaultTemplateName` property defined in [`CoderAppConfig`](types.md#coderappconfig). In the event that both values are present, the YAML file's `templateName` property will always be used instead.
 
-### `templateName`
+### `mode`
 
 **Type:** Optional union of `manual` or `auto`
 


### PR DESCRIPTION
This PR fixes some incorrect descriptions in `backstage-plugin-coder` docs.

- The section's title describing `catalog-info.yaml` was labeled `app-config.yaml`.
- The title for `mode` reference was labeled `templateName`.