### PR TITLE
fix: update component styling to defer more to MUI theme

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -159,7 +159,7 @@ const overviewContent = (
     </Grid>
 
     <Grid item md={6} xs={12}>
-      <CoderProvider appConfig={coderAppConfig} fallbackAuthUiMode="assertive">
+      <CoderProvider appConfig={coderAppConfig}>
         <CoderWorkspacesCard readEntityData />
       </CoderProvider>
     </Grid>

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -159,7 +159,7 @@ const overviewContent = (
     </Grid>
 
     <Grid item md={6} xs={12}>
-      <CoderProvider appConfig={coderAppConfig}>
+      <CoderProvider appConfig={coderAppConfig} fallbackAuthUiMode="assertive">
         <CoderWorkspacesCard readEntityData />
       </CoderProvider>
     </Grid>

--- a/plugins/backstage-plugin-coder/src/components/A11yInfoCard/A11yInfoCard.tsx
+++ b/plugins/backstage-plugin-coder/src/components/A11yInfoCard/A11yInfoCard.tsx
@@ -23,10 +23,10 @@ const useStyles = makeStyles(theme => ({
   },
 
   headerContent: {
-    // Ideally wouldn't be using hard-coded font sizes, but couldn't figure out
-    // how to use the theme.typography property, especially since not all
-    // sub-properties have font sizes defined
-    fontSize: '1.5rem',
+    // Not a fan of using a random <h5> element's styles, but it's the only
+    // typographic category that has a font size of 1.5x the base font size. We
+    // need that size to match the header sizes of the official InfoCard.
+    fontSize: theme.typography.h5.fontSize ?? '1.5rem',
     color: theme.palette.text.primary,
     fontWeight: 700,
     borderBottom: `1px solid ${theme.palette.divider}`,

--- a/plugins/backstage-plugin-coder/src/components/A11yInfoCard/A11yInfoCard.tsx
+++ b/plugins/backstage-plugin-coder/src/components/A11yInfoCard/A11yInfoCard.tsx
@@ -6,6 +6,7 @@
  */
 import React, { type HTMLAttributes, type ReactNode, forwardRef } from 'react';
 import { makeStyles } from '@material-ui/core';
+import { scaleCssUnit } from '../../utils/styling';
 
 export type A11yInfoCardProps = Readonly<
   HTMLAttributes<HTMLDivElement> & {
@@ -23,10 +24,7 @@ const useStyles = makeStyles(theme => ({
   },
 
   headerContent: {
-    // Not a fan of using a random <h5> element's styles, but it's the only
-    // typographic category that has a font size of 1.5x the base font size. We
-    // need that size to match the header sizes of the official InfoCard.
-    fontSize: theme.typography.h5.fontSize ?? '1.5rem',
+    fontSize: scaleCssUnit(theme.typography.body1.fontSize, 1.5),
     color: theme.palette.text.primary,
     fontWeight: 700,
     borderBottom: `1px solid ${theme.palette.divider}`,

--- a/plugins/backstage-plugin-coder/src/components/CoderAuthForm/CoderAuthForm.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderAuthForm/CoderAuthForm.tsx
@@ -45,6 +45,9 @@ export const CoderAuthForm = ({ descriptionId }: CoderAuthFormProps) => {
             return <CoderAuthInputForm />;
           }
 
+          // It shouldn't be possible for these branches to run, because parent
+          // code should show main content instead of the form when the user is
+          // authenticated. Still adding them for extra assurance
           case 'authenticated':
           case 'distrustedWithGracePeriod': {
             return <CoderAuthSuccessStatus />;

--- a/plugins/backstage-plugin-coder/src/components/CoderAuthForm/CoderAuthSuccessStatus.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderAuthForm/CoderAuthSuccessStatus.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles(theme => ({
     marginLeft: 'auto',
     marginRight: 'auto',
     color: theme.palette.text.primary,
-    fontSize: '1rem',
+    fontSize: theme.typography.body1.fontSize,
   },
 
   statusArea: {
@@ -35,13 +35,9 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
   },
 
-  logo: {
-    //
-  },
-
   text: {
     textAlign: 'center',
-    lineHeight: '1rem',
+    lineHeight: theme.typography.body1.fontSize,
   },
 }));
 
@@ -51,8 +47,8 @@ export function CoderAuthSuccessStatus() {
   return (
     <div className={styles.root}>
       <div className={styles.statusArea}>
-        <CoderLogo className={styles.logo} />
-        <p className={styles.text}>You are fully authenticated with Coder!</p>
+        <CoderLogo />
+        <p className={styles.text}>You are fully authenticated with Coder.</p>
       </div>
 
       <UnlinkAccountButton />

--- a/plugins/backstage-plugin-coder/src/components/CoderAuthFormDialog/CoderAuthFormDialog.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderAuthFormDialog/CoderAuthFormDialog.tsx
@@ -60,6 +60,10 @@ const useStyles = makeStyles(theme => ({
   },
 
   closeButton: {
+    // MUI's typography object doesn't expose any letter tracking values, even
+    // though you need them to make sure that all-caps text doesn't bunch up.
+    // Even if the text of the button changes, the styles might look slightly
+    // wonky, but they won't cause any obvious readability/styling issues
     letterSpacing: '0.05em',
     padding: `${theme.spacing(0.5)}px ${theme.spacing(1)}px`,
     color: theme.palette.primary.main,

--- a/plugins/backstage-plugin-coder/src/components/CoderAuthFormDialog/CoderAuthFormDialog.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderAuthFormDialog/CoderAuthFormDialog.tsx
@@ -7,6 +7,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogActions from '@material-ui/core/DialogActions';
 import { CoderAuthForm } from '../CoderAuthForm/CoderAuthForm';
+import { scaleCssUnit } from '../../utils/styling';
 
 const useStyles = makeStyles(theme => ({
   trigger: {
@@ -41,7 +42,7 @@ const useStyles = makeStyles(theme => ({
   },
 
   dialogTitle: {
-    fontSize: theme.typography.h5.fontSize ?? '24px',
+    fontSize: scaleCssUnit(theme.typography.body1.fontSize, 1.5),
     borderBottom: `${theme.palette.divider} 1px solid`,
     padding: `${theme.spacing(1)}px ${theme.spacing(3)}px`,
   },

--- a/plugins/backstage-plugin-coder/src/components/CoderAuthFormDialog/CoderAuthFormDialog.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderAuthFormDialog/CoderAuthFormDialog.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles(theme => ({
   },
 
   dialogTitle: {
-    fontSize: '24px',
+    fontSize: theme.typography.h5.fontSize ?? '24px',
     borderBottom: `${theme.palette.divider} 1px solid`,
     padding: `${theme.spacing(1)}px ${theme.spacing(3)}px`,
   },

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/CreateWorkspaceLink.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles<Theme, StyleInput, StyleKeys>(theme => {
       justifyContent: 'center',
       alignItems: 'center',
       backgroundColor: 'inherit',
-      borderRadius: '9999px',
+      borderRadius: theme.shape.borderRadius,
       lineHeight: 1,
       color: canCreateWorkspace
         ? theme.palette.text.primary

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ExtraActionsButton.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/ExtraActionsButton.tsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles(theme => {
       width: theme.spacing(4) + padding,
       height: theme.spacing(4) + padding,
       border: 'none',
-      borderRadius: '9999px',
+      borderRadius: theme.shape.borderRadius,
       backgroundColor: 'inherit',
       lineHeight: 1,
 

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/HeaderRow.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/HeaderRow.tsx
@@ -2,6 +2,7 @@ import React, { HTMLAttributes, ReactNode } from 'react';
 import { type Theme, makeStyles } from '@material-ui/core';
 import { useWorkspacesCardContext } from './Root';
 import type { HtmlHeader } from '../../typesConstants';
+import { scaleCssUnit } from '../../utils/styling';
 
 type StyleKey = 'root' | 'header' | 'hgroup' | 'subheader';
 const useStyles = makeStyles<Theme, {}, StyleKey>(theme => ({
@@ -18,17 +19,16 @@ const useStyles = makeStyles<Theme, {}, StyleKey>(theme => ({
   },
 
   header: {
-    // Want the header text to be set solid (typography term for setting line
-    // height equal to font size) to reduce gaps between it and the subtitle,
-    // but only MUI's h3 line height is the smallest value/closest match
-    lineHeight: theme.typography.h3.lineHeight ?? 1,
-    fontSize: theme.typography.h5.fontSize ?? '1.5rem',
+    // Setting line height solid (when leading and font size are equal) to make
+    // it easier for header and subtitle to sit next to each other
+    lineHeight: 1,
+    fontSize: scaleCssUnit(theme.typography.body1.fontSize, 1.5),
     margin: 0,
   },
 
   subheader: {
     margin: '0',
-    fontSize: theme.typography.subtitle2.fontSize ?? '0.875rem',
+    fontSize: scaleCssUnit(theme.typography.body1.fontSize, 0.875),
     fontWeight: 400,
     color: theme.palette.text.secondary,
     paddingTop: theme.spacing(0.5),

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/HeaderRow.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/HeaderRow.tsx
@@ -18,14 +18,17 @@ const useStyles = makeStyles<Theme, {}, StyleKey>(theme => ({
   },
 
   header: {
-    fontSize: '1.5rem',
-    lineHeight: 1,
+    // Want the header text to be set solid (typography term for setting line
+    // height equal to font size) to reduce gaps between it and the subtitle,
+    // but only MUI's h3 line height is the smallest value/closest match
+    lineHeight: theme.typography.h3.lineHeight ?? 1,
+    fontSize: theme.typography.h5.fontSize ?? '1.5rem',
     margin: 0,
   },
 
   subheader: {
     margin: '0',
-    fontSize: '0.875rem',
+    fontSize: theme.typography.subtitle2.fontSize ?? '0.875rem',
     fontWeight: 400,
     color: theme.palette.text.secondary,
     paddingTop: theme.spacing(0.5),

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Placeholder.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/Placeholder.tsx
@@ -11,6 +11,7 @@ import { useWorkspacesCardContext } from './Root';
 import { makeStyles } from '@material-ui/core';
 import { CoderLogo } from '../CoderLogo';
 import { VisuallyHidden } from '../VisuallyHidden';
+import { scaleCssUnit } from '../../utils/styling';
 
 const usePlaceholderStyles = makeStyles(theme => ({
   root: {
@@ -24,7 +25,7 @@ const usePlaceholderStyles = makeStyles(theme => ({
     textAlign: 'center',
     padding: `0 ${theme.spacing(2.5)}px`,
     fontWeight: 400,
-    fontSize: '1.125rem',
+    fontSize: scaleCssUnit(theme.typography.body1.fontSize, 1.125),
     color: theme.palette.text.secondary,
     lineHeight: 1.1,
   },

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/SearchBox.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/SearchBox.tsx
@@ -14,6 +14,7 @@ import { Theme, makeStyles } from '@material-ui/core';
 import { useWorkspacesCardContext } from './Root';
 import SearchIcon from '@material-ui/icons/Search';
 import CloseIcon from '@material-ui/icons/Close';
+import { CUSTOM_FOCUS_COLOR } from '../../utils/styling';
 
 const LABEL_TEXT = 'Search your Coder workspaces';
 const SEARCH_DEBOUNCE_MS = 400;
@@ -50,7 +51,7 @@ const useStyles = makeStyles<Theme, MakeStylesInput, StyleKey>(theme => ({
     },
 
     '&:focus-within': {
-      boxShadow: '0 0 0 1px hsl(213deg, 94%, 68%)',
+      boxShadow: `0 0 0 1px ${CUSTOM_FOCUS_COLOR}`,
     },
 
     // Makes it so that the container doesn't have visible focus while you're
@@ -93,7 +94,7 @@ const useStyles = makeStyles<Theme, MakeStylesInput, StyleKey>(theme => ({
     cursor: 'pointer',
 
     '&:focus': {
-      boxShadow: '0 0 0 1px hsl(213deg, 94%, 68%)',
+      boxShadow: `0 0 0 1px ${CUSTOM_FOCUS_COLOR}`,
     },
   }),
 }));

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesListIcon.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesListIcon.tsx
@@ -1,6 +1,7 @@
 import React, { ForwardedRef, HTMLAttributes, useState } from 'react';
 import { useUrlSync } from '../../hooks/useUrlSync';
 import { Theme, makeStyles } from '@material-ui/core';
+import { scaleCssUnit } from '../../utils/styling';
 
 type WorkspaceListIconProps = Readonly<
   Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'aria-hidden'> & {
@@ -21,7 +22,7 @@ const useStyles = makeStyles<Theme, MakeStylesInput, StyleKey>(theme => ({
   root: {
     width: theme.spacing(2.5),
     height: theme.spacing(2.5),
-    fontSize: '0.625rem',
+    fontSize: scaleCssUnit(theme.typography.body1.fontSize, 0.625),
     backgroundColor: theme.palette.background.default,
     borderRadius: '9999px',
     display: 'flex',

--- a/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesListItem.tsx
+++ b/plugins/backstage-plugin-coder/src/components/CoderWorkspacesCard/WorkspacesListItem.tsx
@@ -82,7 +82,7 @@ const useStyles = makeStyles<Theme, UseStyleInputs, StyleKey>(theme => ({
     alignItems: 'center',
     gap: theme.spacing(1),
     color: theme.palette.text.secondary,
-    fontSize: '16px',
+    fontSize: theme.typography.body1.fontSize ?? '1rem',
   },
 
   onlineStatusLight: ({ isAvailable }) => ({

--- a/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.tsx
+++ b/plugins/backstage-plugin-coder/src/components/Disclosure/Disclosure.tsx
@@ -1,13 +1,14 @@
 import React, { type HTMLAttributes, type ReactNode, useState } from 'react';
 import { useId } from '../../hooks/hookPolyfills';
 import { makeStyles } from '@material-ui/core';
+import { scaleCssUnit } from '../../utils/styling';
 
 const useStyles = makeStyles(theme => ({
   disclosureTriangle: {
     display: 'inline-block',
     textAlign: 'right',
     width: theme.spacing(2.25),
-    fontSize: '0.7rem',
+    fontSize: scaleCssUnit(theme.typography.body1.fontSize, 0.7),
   },
 
   disclosureBody: {

--- a/plugins/backstage-plugin-coder/src/utils/styling.ts
+++ b/plugins/backstage-plugin-coder/src/utils/styling.ts
@@ -1,3 +1,10 @@
+/**
+ * A custom focus color chosen to look close to a system default, while
+ * remaining visible in dark and light themes. The focus values from Backstage's
+ * theme object are too low-contrast to meet accessibility requirements.
+ */
+export const CUSTOM_FOCUS_COLOR = 'hsl(213deg, 94%, 68%)';
+
 export function scaleCssUnit(
   baseSize: string | number | undefined,
   scale: number,

--- a/plugins/backstage-plugin-coder/src/utils/styling.ts
+++ b/plugins/backstage-plugin-coder/src/utils/styling.ts
@@ -1,0 +1,30 @@
+export function scaleCssUnit(
+  baseSize: string | number | undefined,
+  scale: number,
+): string {
+  if (!Number.isFinite(scale)) {
+    return '1rem';
+  }
+
+  if (baseSize === undefined) {
+    return `${scale}rem`;
+  }
+
+  if (typeof baseSize === 'number') {
+    if (!Number.isFinite(baseSize)) {
+      return `${scale}rem`;
+    }
+
+    return `${baseSize * scale}px`;
+  }
+
+  const sizeRe = /^\s*(?<value>\d+(?:\.\d+))?s*(?<unit>px|r?em)\s*$/i;
+  const { value, unit } = sizeRe.exec(baseSize)?.groups ?? {};
+  const numValue = Number(value);
+
+  if (Number.isNaN(numValue) || unit === undefined) {
+    return `${scale}rem`;
+  }
+
+  return `${scale * numValue}${unit}`;
+}


### PR DESCRIPTION
Part 1 of making sure that the plugins are ready for Spotify Portal (https://github.com/coder/customers/issues/676)


## Changes made
- Updated almost all theme values to defer to the theme object. This is especially important in Spotify Portal, as the platform is much more locked down and provides far fewer options for customizing appearance.

## Notes
- Not all values were updated, and you'll likely notice a few values that are still based in hard-coded (particularly `line-height`. I wish I could remove them, but they are there intentionally.
   - MUI's base theme object is not robust enough to deal with serious typographic considerations, and it especially can't handle optical adjustments to make sure UI looks good rather than mathematically correct. All of these values are low-risk, though, especially with Spotify Portal likely to choose reasonable UI defaults for its values.